### PR TITLE
Add FalonSocial python-sorter repo

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -5,3 +5,4 @@
 - git://github.com/pre-commit/mirrors-jshint
 - git://github.com/pre-commit/mirrors-ruby-lint
 - git://github.com/pre-commit/mirrors-scss-lint
+- git://github.com/FalconSocial/pre-commit-python-sorter


### PR DESCRIPTION
I wrote a pre-commit plugin that will sort your python modules for you.

https://github.com/FalconSocial/pre-commit-python-sorter
