### PR TITLE
Add Robot Framework Tidy wrapper repo

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -7,3 +7,4 @@
 - git://github.com/pre-commit/mirrors-ruby-lint
 - git://github.com/pre-commit/mirrors-scss-lint
 - git://github.com/FalconSocial/pre-commit-python-sorter
+- git://github.com/guykisel/pre-commit-robotframework-tidy


### PR DESCRIPTION
I wrote a pre-commit hook that runs Robot Framework's Tidy tool (tidies up formatting) on .robot files.

https://github.com/guykisel/pre-commit-robotframework-tidy
