### PR TITLE
Add pre-commit-mirrors-pep257 repository

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -8,3 +8,4 @@
 - git://github.com/pre-commit/mirrors-scss-lint
 - git://github.com/FalconSocial/pre-commit-python-sorter
 - git://github.com/guykisel/pre-commit-robotframework-tidy
+- git://github.com/FalconSocial/pre-commit-mirrors-pep257


### PR DESCRIPTION
We have added a mirror repository for the PEP257 utility. Please add it to the web page.
