### PR TITLE
Added documentation on how arguments are passed by pre-commit to the hooks

### DIFF
--- a/index.mako
+++ b/index.mako
@@ -218,6 +218,28 @@
 </pre>
             <p>This will pass <code>--max-line-length=131</code> to <code>flake8</code>.</p>
 
+            <h3>Arguments Pattern in hooks</h3>
+            <p>If you are writing your own custom hook as a <code>script</code>-type or even a <code>system<code> hook, your hook should expect to receive the 'args' value and then a list of staged files.</p>
+
+            <p>For example, assuming your .pre-commit-config.yaml was like below</p>
+            <pre>
+            -   repo: git://github.com/path/to/your/hook/repo
+                sha: a751eb58f91d8fa70e8b87c9c95777c5a743a932
+                hooks:
+                - id: my-hook-script-id
+                  args: [--myarg1=1 --myarg1=2]
+            </pre>
+
+            <p>When you next run pre-commit, it will pass on those args together with </p>
+            <pre>
+            path/to/script-or-system-call --myarg1=1 --myarg1=2 dir/file1 dir/file2 file3
+            </pre>
+
+            <p>If the 'args' property is empty or not defined, you should expect pre-commit to be calling your script/command like so </p>
+            <pre>
+            path/to/script-or-system-call dir/file1 dir/file2 file3
+            </pre>
+
             <h2 id="overriding-language-version">Overriding Language Version</h2>
             <p>Sometimes you only want to run the hooks on a specific version of the language. For each language, they default to using the system installed language (So for example if I&rsquo;m running <code>python2.6</code> and a hook specifies <code>python</code>, pre-commit will run the hook using <code>python2.6</code>). Sometimes you don&rsquo;t want the default system installed version so you can override this on a per-hook basis by setting the <code>language_version</code>.</p>
 <pre>


### PR DESCRIPTION
Some notes on how arguments are passed to the script/command. I think this will be useful for those that need to create script or system type hooks.

I have been writing some custom hooks (for PHP) with the pre-commit framework. What I tend to struggle with was understanding how the arguments from the `args` property and the list of staged files were passed on to the hook entry for final execution.

I found the site did not mention how this was done and resulted in me having to do several tries to figure it out. 

Feel free to edit the wording if needed. I just needed this for my own reference.
