### PR TITLE
Add hook to reject large files

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -9,3 +9,4 @@
 - git://github.com/FalconSocial/pre-commit-python-sorter
 - git://github.com/guykisel/pre-commit-robotframework-tidy
 - git://github.com/FalconSocial/pre-commit-mirrors-pep257
+- git://github.com/guykisel/pre-commit-reject-large-files


### PR DESCRIPTION
https://github.com/guykisel/pre-commit-reject-large-files

This hook rejects any files that are over a specified size (defaults to 5 MB).
