### PR TITLE
Add pre-commit-sphinx to list of hook repositories

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -136,3 +136,4 @@
 - https://github.com/maltzj/google-style-precommit-hook
 - https://github.com/jvstein/pre-commit-dotnet-format
 - https://github.com/hakancelik96/unimport
+- https://github.com/thclark/pre-commit-sphinx


### PR DESCRIPTION
I've added a hook for building documentation with sphinx, so that commits fail if they break documentation builds.