### PR TITLE
Removed deprecated "mirrors-isort" repository from all-repos.yaml.

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -5,7 +5,6 @@
 - https://github.com/pre-commit/mirrors-csslint
 - https://github.com/pre-commit/mirrors-eslint
 - https://github.com/pre-commit/mirrors-fixmyjs
-- https://github.com/pre-commit/mirrors-isort
 - https://github.com/pre-commit/mirrors-jshint
 - https://github.com/pre-commit/mirrors-mypy
 - https://github.com/pre-commit/mirrors-puppet-lint


### PR DESCRIPTION
Fixes #367