### PR TITLE
docs: add swiftformat hook

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -136,3 +136,4 @@
 - https://github.com/jvstein/pre-commit-dotnet-format
 # - https://github.com/hakancelik96/unimport
 - https://github.com/PeterMosmans/jenkinslint
+- https://github.com/nicklockwood/SwiftFormat


### PR DESCRIPTION
I created one pre-commit hook for [swiftformat](https://github.com/nicklockwood/SwiftFormat). This PR is to add the repo to the site for other swift devs to find. 