### PR TITLE
Add doc8 and prospector

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -76,6 +76,8 @@
 - https://github.com/PyCQA/bandit
 - https://github.com/PyCQA/pydocstyle
 - https://github.com/PyCQA/pylint
+- https://github.com/PyCQA/doc8
+- https://github.com/PyCQA/prospector
 - https://github.com/miki725/importanize
 - https://github.com/motet-a/jinjalint
 - https://github.com/milin/giticket


### PR DESCRIPTION
Assuming I have understood how hooks are defined and added to the https://pre-commit.com/hooks.html list, two of the PyCQA repositories were missing.