### PR TITLE
Add radix-ai/auto-smart-commit

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -140,3 +140,4 @@
 - https://github.com/hukkinj1/mdformat
 - https://gitlab.com/daverona/pre-commit/php
 - https://github.com/anderseknert/pre-commit-opa
+- https://github.com/radix-ai/auto-smart-commit


### PR DESCRIPTION
This PR:
- ~~Sorts all hooks alphabetically to help improve browsability on https://pre-commit.com/hooks.html. The only exception to this rule is that all of the pre-commit organisation's hooks are listed first.~~
- Adds a new hook https://github.com/radix-ai/auto-smart-commit that automatically formats commit messages as [Jira smart commits](https://confluence.atlassian.com/fisheye/using-smart-commits-960155400.html).