### PR TITLE
Change example to use modern flake8 hook

### DIFF
--- a/index.mako
+++ b/index.mako
@@ -1225,8 +1225,8 @@ arguments by specifying the [`args`](#config-args) property in your `.pre-commit
 as follows:
 
 ```yaml
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v1.2.3
+-   repo: https://gitlab.com/PyCQA/flake8
+    rev: 3.8.3
     hooks:
     -   id: flake8
         args: [--max-line-length=131]


### PR DESCRIPTION
The hook that this project is referring to was removed. It's best to point people to the newer flake8 repo and a modern version.