### PR TITLE
Improve doc on autoupdate CLI options

### DIFF
--- a/index.mako
+++ b/index.mako
@@ -798,9 +798,9 @@ Auto-update pre-commit config to the latest repos' versions.
 
 Options:
 
-- `--bleeding-edge`: update to the bleeding edge of the default branch instead
-  of the latest tagged version (the default behaviour).
-- `--freeze`: _new in 1.21.0_): Store "frozen" hashes in [`rev`](#repos-rev)
+- `--bleeding-edge`: Update to the latest commit (bleeding edge) of the default branch.
+  Default behaviour is to use the latest tagged version.
+- `--freeze`: _new in 1.21.0_: Store "frozen" hashes in [`rev`](#repos-rev)
   instead of tag names.
 - `--repo REPO`: _new in 1.4.1_: Only update this repository. _new in 1.7.0_:
   This option may be specified multiple times.


### PR DESCRIPTION
- Make clearer what the default behaviour really is
- Remove a leftover closing bracket
- Make clear it uses latest commit because bleeding edge might be ambiguous. (Is that even correct that it uses latest commit? Didn't know what else bleeding edge could mean.)