### PR TITLE
Adds cmake-format-precommit to list of all_repos

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -104,7 +104,6 @@
 - https://github.com/codingjoe/relint
 - https://github.com/nix-community/nixpkgs-fmt
 - https://github.com/d6e/beancount-check
-- https://github.com/iconmaster5326/cmake-format-pre-commit-hook
 # - https://github.com/thg-consulting/inspectortiger
 - https://gitlab.com/iamlikeme/nbhooks
 - https://github.com/Kuniwak/vint

--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -143,3 +143,4 @@
 - https://github.com/anderseknert/pre-commit-opa
 - https://github.com/radix-ai/auto-smart-commit
 - https://github.com/thibaudcolas/curlylint
+- https://github.com/cheshirekow/cmake-format-precommit


### PR DESCRIPTION
Adds the official cmake-format-precommit hook to the list of repos.

Should the other cmake-format hook be removed from the all_repos.yaml hooks? It's more or less the same but is not the official one. I elected to leave it for now.