### PR TITLE
Use the "literal" block style instead of the "folded" one

### DIFF
--- a/index.mako
+++ b/index.mako
@@ -1477,7 +1477,7 @@ the `(?x)` regex flag.
 ```yaml
 # ...
     -   id: my-hook
-        exclude: >
+        exclude: |
             (?x)^(
                 path/to/file1.py|
                 path/to/file2.py|


### PR DESCRIPTION
Verbose regular expressions allow comments, but if we use "folded"
multiline strings, then the comment will also comment out the
remainder of the regular expression.