### PR TITLE
add new repo for JVM hooks

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -148,3 +148,4 @@
 - https://github.com/nbQA-dev/nbQA
 - https://github.com/Scony/godot-gdscript-toolkit
 - https://github.com/avilaton/add-msg-issue-prefix-hook
+- https://github.com/dustinsand/pre-commit-jvm


### PR DESCRIPTION
Currently contains one hook to run the Detekt static analyzer on Kotlin source files.