### PR TITLE
Add elixir-pre-commit-hooks to all_repos.yaml

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -150,3 +150,4 @@
 - https://github.com/avilaton/add-msg-issue-prefix-hook
 - https://github.com/dustinsand/pre-commit-jvm
 - https://github.com/alan-turing-institute/CleverCSV-pre-commit
+- https://gitlab.com/jvenom/elixir-pre-commit-hooks


### PR DESCRIPTION
I didn't see any existing pre-commit hooks for Elixir, so I'm adding these. I currently have hooks for `mix format` and `mix test`, with more planned in the future.