### PR TITLE
Add editorconfig-checker hooks repo

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -151,3 +151,4 @@
 - https://github.com/dustinsand/pre-commit-jvm
 - https://github.com/alan-turing-institute/CleverCSV-pre-commit
 - https://gitlab.com/jvenom/elixir-pre-commit-hooks
+- https://github.com/skycaptain/pre-commit-editorconfig-checker


### PR DESCRIPTION
[editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker) is a tool to verify that your files are in harmony with your [.editorconfig](https://editorconfig.org/).

The repo adds this via the Python wrapper project: https://github.com/editorconfig-checker/editorconfig-checker.python