### PR TITLE
mention license on main page

### DIFF
--- a/index.mako
+++ b/index.mako
@@ -1805,6 +1805,16 @@ automatically).
 ''')}
         </div>
 
+        <div id="license">
+            <div class="page-header">${md('# License')}</div>
+
+${md('''
+pre-commit is made available under the terms of [the MIT license].
+
+[the MIT license]: https://github.com/pre-commit/pre-commit/blob/master/LICENSE
+''')}
+        </div>
+
         <div id="contributing">
             <div class="page-header">${md('# Contributing')}</div>
 


### PR DESCRIPTION
As things are, the only way to see the license for pre-commit is on the project's GitHub page or in the source.