### PR TITLE
docs: add new repository hooks

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -151,3 +151,4 @@
 - https://github.com/dustinsand/pre-commit-jvm
 - https://github.com/alan-turing-institute/CleverCSV-pre-commit
 - https://gitlab.com/jvenom/elixir-pre-commit-hooks
+- https://github.com/gabitchov/pre-commit-hooks


### PR DESCRIPTION
This PR add mine hooks repository that contains a EClint hook, so far.