### PR TITLE
Add editorconfig-checker hooks repo

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -154,3 +154,4 @@
 - https://github.com/Cretezy/flutter-format-pre-commit
 - https://github.com/dluksza/flutter-analyze-pre-commit
 - https://github.com/fluttercommunity/import_sorter
+- https://github.com/editorconfig-checker/editorconfig-checker.python


### PR DESCRIPTION
[editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker) is a tool to verify that your files are in harmony with your [.editorconfig](https://editorconfig.org/).

The repo adds this via the Python wrapper project: https://github.com/editorconfig-checker/editorconfig-checker.python

This is the second attempt after #415 got rejected. Upstream now provides a `.pre-commit-hooks.yaml`.