### PR TITLE
added init-templatedir example windows cmd/ps

### DIFF
--- a/index.mako
+++ b/index.mako
@@ -949,6 +949,18 @@ git config --global init.templateDir ~/.git-template
 pre-commit init-templatedir ~/.git-template
 ```
 
+For Windows cmd.exe use `%HOMEPATH%` instead of `~`:
+
+```batch
+pre-commit init-templatedir %HOMEPATH%\.git-template
+```
+
+For Windows PowerShell use `$HOME` instead of `~`:
+
+```powershell
+pre-commit init-templatedir $HOME\.git-template
+```
+
 Now whenever a repository is cloned or created, it will have the hooks set up
 already!
 


### PR DESCRIPTION
added example which uses windows environment variables instead of the ~
(see https://github.com/pre-commit/pre-commit/issues/1720#issuecomment-735304274)