### PR TITLE
Add pre-commit-lua-formatter hook

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -155,3 +155,4 @@
 - https://github.com/dluksza/flutter-analyze-pre-commit
 - https://github.com/fluttercommunity/import_sorter
 - https://github.com/editorconfig-checker/editorconfig-checker.python
+- https://gitlab.com/pablodiehl/pre-commit-lua-formatter


### PR DESCRIPTION
This commit adds a hook that runs [LuaFormatter](https://github.com/LuaDevelopmentTools/luaformatter) on Lua files.