### PR TITLE
added id and type filter for hooks

### DIFF
--- a/assets/filter_repos.js
+++ b/assets/filter_repos.js
@@ -1,0 +1,41 @@
+'use strict';
+
+(() => {
+    const searchInput = document.getElementById('search-hook-id');
+    const selectInput = document.getElementById('select-hook-type');
+
+    const hooks = document.getElementById('hooks');
+    const repos = hooks.getElementsByTagName('ul');
+
+    const filterHooks = () => {
+        const id = searchInput.value.toLowerCase();
+        const type = selectInput.value;
+
+        for (let i = 0; i < repos.length; i += 1) {
+            const repo = repos[i];
+            let hasVisibleHooks = false;
+            const repoHooks = repo.getElementsByTagName('li');
+
+            if (repoHooks) {
+                for (let j = 0; j < repoHooks.length; j += 1) {
+                    const repoHook = repoHooks[j];
+                    const hookId = repoHook.dataset.id.toLowerCase();
+                    const hookTypes = repoHook.dataset.types;
+
+                    if (hookId.includes(id) && hookTypes.includes(type)) {
+                        repoHook.hidden = false;
+                        hasVisibleHooks = true;
+                    } else {
+                        repoHook.hidden = true;
+                    }
+                }
+            }
+
+            repo.hidden = !hasVisibleHooks;
+            hooks.querySelector(`h3[data-repo="${repo.dataset.repo}"]`).hidden = !hasVisibleHooks;
+        }
+    };
+
+    searchInput.addEventListener('input', filterHooks);
+    selectInput.addEventListener('change', filterHooks);
+})();

--- a/hooks.mako
+++ b/hooks.mako
@@ -3,6 +3,22 @@
 
 <div class="page-header"><h1>Supported hooks</h1></div>
 
+<div class="row">
+    <div class="col-xs-6 form-group">
+        <label for="search-hook-id">Filter hook id:</label>
+        <input id="search-hook-id" type="text" placeholder="filter hook id" class="form-control"></input>
+    </div>
+    <div class="col-xs-6 form-group">
+        <label for="search-hook-id">Filter hook type:</label>
+        <select id="select-hook-type" class="form-control">
+            <option value="">--</option>
+            % for hook_type in sorted(all_types, key=str.lower):
+                <option value="${hook_type}">${hook_type}</option>
+            % endfor
+        </select>
+    </div>
+</div>
+
 <p>
 To add to this list, fork <a href="https://github.com/pre-commit/pre-commit.com">this repository</a>.
 </p>
@@ -11,15 +27,16 @@ To add to this list, fork <a href="https://github.com/pre-commit/pre-commit.com"
 Also available in <a href="/all-hooks.json">json</a>.
 </p>
 
+<div id="hooks">
 % for repository, hooks in all_hooks.items():
-    <h3>
+    <h3 data-repo="${repository}">
         <a href="${repository}" target="_blank">
             ${repository.replace('https://', '')}
         </a>
     </h3>
-    <ul>
+    <ul data-repo="${repository}">
         % for hook_dict in hooks:
-            <li>
+            <li data-id="${hook_dict['id']}" data-types="${', '.join(hook_dict.get('types', []) + hook_dict.get('types_or', []))}">
                 <code>${hook_dict['id']}</code>
                 % if 'description' in hook_dict:
                     - ${hook_dict['description']}
@@ -30,3 +47,6 @@ Also available in <a href="/all-hooks.json">json</a>.
         % endfor
     </ul>
 % endfor
+</div>
+
+<script src="assets/filter_repos.js"></script>

--- a/make_templates.py
+++ b/make_templates.py
@@ -25,7 +25,14 @@ def get_env() -> Dict[str, Any]:
         open('all-hooks.json').read(),
         object_pairs_hook=collections.OrderedDict,
     )
-    return {'all_hooks': all_hooks}
+    all_types = {
+        hook_type
+        for properties in all_hooks.values()
+        for hook_type in (
+            properties[0].get("types", []) + properties[0].get("types_or", [])
+        )
+    }
+    return {'all_hooks': all_hooks, 'all_types': all_types}
 
 
 def main() -> int:


### PR DESCRIPTION
resolves #341 

- options for select are automatically generated and only include types for hooks that are in `all-hooks.json`
- also added a search input for the hook id
- repos with non-matching hooks are completely hidden