### PR TITLE
Update pre-commit hooks version in docs

### DIFF
--- a/index.mako
+++ b/index.mako
@@ -121,7 +121,7 @@ pre-commit --version
 ```yaml
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v3.4.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer


### PR DESCRIPTION
The docs are linking to [v2.3.0](https://github.com/pre-commit/pre-commit-hooks/releases/tag/v2.3.0) which was released in August 2019. One problem is that some of the [supported hooks](https://pre-commit.com/hooks.html) don't exist in this older version (like `destroyed-symlinks`) which leads to a failure if you follow along with the instructions and try use all "Supported Hooks".