### PR TITLE
Add blocklint to list of hook repositories

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -159,3 +159,4 @@
 - https://github.com/frnmst/md-toc
 - https://github.com/mgedmin/check-manifest
 - https://github.com/ecugol/pre-commit-hooks-django
+- https://github.com/PrincetonUniversity/blocklint


### PR DESCRIPTION
Blocklint is a python-based linter for checking any text or source code file for the usage of blocklisted words such as master/slave.  The list of words and sensitivity to case and word boundaries can be configured but the defaults are meant to promote inclusive language in source code.