### PR TITLE
Add check-jsonschema to all-repos.yaml

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -160,3 +160,4 @@
 - https://github.com/mgedmin/check-manifest
 - https://github.com/ecugol/pre-commit-hooks-django
 - https://github.com/PrincetonUniversity/blocklint
+- https://github.com/sirosen/check-jsonschema


### PR DESCRIPTION
I didn't see another hook which fulfilled this niche, so I've written one which takes care of applying jsonschema validation to JSON or YAML files.

I welcome feedback on the hook itself, if it needs to pass some standard of quality before it can be added. (e.g. I didn't write any tests for it yet.)