### PR TITLE
Add jupytext to list of hooks

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -165,3 +165,4 @@
 - https://github.com/sondrelg/pep585-upgrade
 - https://github.com/jendrikseipp/vulture
 - https://github.com/MarcoGorelli/no-string-hints
+- https://github.com/mwouts/jupytext


### PR DESCRIPTION
* We recently added official pre-commit hook support to jupytext, a program which updates Python notebooks to/from text file representations.

Look forward to seeing this included in the official list of hooks @asottile 😁 