### PR TITLE
Add pre-commit-maven to the list of hook repositories

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -166,3 +166,4 @@
 - https://github.com/jendrikseipp/vulture
 - https://github.com/MarcoGorelli/no-string-hints
 - https://github.com/mwouts/jupytext
+- https://github.com/ejba/pre-commit-maven


### PR DESCRIPTION
The **pre-commit-maven** goal is running [spotless](https://github.com/diffplug/spotless) (and other plugins) in maven-based projects.