### PR TITLE
added tflint pre-commit from source.

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -167,3 +167,4 @@
 - https://github.com/MarcoGorelli/no-string-hints
 - https://github.com/mwouts/jupytext
 - https://github.com/ejba/pre-commit-maven
+- https://github.com/terraform-linters/tflint


### PR DESCRIPTION
Added tflint pre-commit from the creators of tflint. Uses golang to install, which is different than the ones currently in the list which expect the binary.