### PR TITLE
Add tfsec from source

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -168,3 +168,4 @@
 - https://github.com/mwouts/jupytext
 - https://github.com/ejba/pre-commit-maven
 - https://github.com/terraform-linters/tflint
+- https://github.com/tfsec/tfsec


### PR DESCRIPTION
Added TFSec pre-commit from TFSec repo. Different than the current tfsec hooks as this builds the package directly from go instead of expecting it to be pre-built on the system.