### PR TITLE
Add official hadolint repository hook

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -25,6 +25,7 @@
 - https://github.com/asottile/dead
 - https://github.com/asottile/setup-cfg-fmt
 - https://github.com/asottile/cheetah_lint
+- https://github.com/hadolint/hadolint
 - https://github.com/digitalpulp/pre-commit-php
 - https://github.com/elidupuis/mirrors-jscs
 - https://github.com/elidupuis/mirrors-sass-lint

--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -25,7 +25,6 @@
 - https://github.com/asottile/dead
 - https://github.com/asottile/setup-cfg-fmt
 - https://github.com/asottile/cheetah_lint
-- https://github.com/hadolint/hadolint
 - https://github.com/digitalpulp/pre-commit-php
 - https://github.com/elidupuis/mirrors-jscs
 - https://github.com/elidupuis/mirrors-sass-lint
@@ -171,3 +170,4 @@
 - https://github.com/terraform-linters/tflint
 - https://github.com/tfsec/tfsec
 - https://github.com/yoheimuta/protolint
+- https://github.com/hadolint/hadolint


### PR DESCRIPTION
There was already an existing hook listed for hadolint, but the official hadolint repository has now added their own pre-commit hooks.

https://github.com/hadolint/hadolint/pull/523
https://github.com/hadolint/hadolint/pull/527