### PR TITLE
Add new pre-commit hook for Flutter 

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -172,3 +172,4 @@
 - https://github.com/yoheimuta/protolint
 - https://github.com/hadolint/hadolint
 - https://github.com/google/go-jsonnet
+- https://github.com/guid-empty/flutter-dependency-validation-pre-commit


### PR DESCRIPTION
Hello.

Is it possible to add new flutter dependency validation pre-commit hook to be shown then here - https://pre-commit.com/hooks.html?

Hook and some documentation is available here https://github.com/guid-empty/flutter-dependency-validation-pre-commit.

Thank you.