### PR TITLE
Add cpplint to the List of Supported Hooks

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -173,3 +173,4 @@
 - https://github.com/hadolint/hadolint
 - https://github.com/google/go-jsonnet
 - https://github.com/guid-empty/flutter-dependency-validation-pre-commit
+- https://github.com/cpplint/cpplint


### PR DESCRIPTION
A pre-commit hook was added to `cpplint` via this [pull-request](https://github.com/cpplint/cpplint/pull/168)
Here I want to update the list of supported hooks on `pre-commit.com`.
The latest cpplint version hasn't been release yet