### PR TITLE
Add flake2lint: Tool and pre-commit hook to augment Flake8 noqa comme…

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -175,3 +175,4 @@
 - https://github.com/guid-empty/flutter-dependency-validation-pre-commit
 - https://github.com/cpplint/cpplint
 - https://github.com/MarcoGorelli/abs-imports
+- https://github.com/domdfcoding/flake2lint


### PR DESCRIPTION
…nts with PyLint comments.

As mentioned on https://flake2lint.readthedocs.io/en/latest/usage.html#pre-commit-hook
```
- repo: https://github.com/domdfcoding/flake2lint
  rev: v0.3.0
  hooks:
  - id: flake2lint
```