### PR TITLE
Add AleksaC/hadolint-py, AleksaC/circleci-cli-py and AleksaC/mirrors-cfn-nag

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -178,3 +178,6 @@
 - https://github.com/domdfcoding/flake2lint
 - https://github.com/dotnet/format
 - https://github.com/ashwin153/pre-commit-vagrant
+- https://github.com/AleksaC/hadolint-py
+- https://github.com/AleksaC/circleci-cli-py
+- https://github.com/AleksaC/mirrors-cfn-nag


### PR DESCRIPTION
I added the following hooks I've created and been using for a few months:
- https://github.com/AleksaC/hadolint-py
- https://github.com/AleksaC/circleci-cli-py
- https://github.com/AleksaC/mirrors-cfn-nag

The first two work like `shellcheck-py` and allow hadolint and circleci config validation to be ran without system installation or docker. The last one is a wrapper around `cfn_nag_scan` that allows it to be ran on multiple files.

All the repos are keeping up with versions using a scheduled circleci job. The way update works isn't great but I don't think it can break unless some of the repos changes their versioning. 