### PR TITLE
Add cmake-lint to supported tools.

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -180,3 +180,4 @@
 - https://github.com/AleksaC/hadolint-py
 - https://github.com/AleksaC/circleci-cli-py
 - https://github.com/AleksaC/mirrors-cfn-nag
+- https://github.com/cmake-lint/cmake-lint


### PR DESCRIPTION
CMake-lint is a linter for CMakeFiles. Support for pre-commit was added in commit:
https://github.com/cmake-lint/cmake-lint/commit/f214fecd42cef2aa623742dc9888725bc99d32ba