### PR TITLE
Add travis-lint

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -182,3 +182,4 @@
 - https://github.com/AleksaC/mirrors-cfn-nag
 - https://github.com/cmake-lint/cmake-lint
 - https://github.com/priv-kweihmann/oelint-adv
+- https://github.com/proinsias/travis-lint


### PR DESCRIPTION
Adds a linter of `.travis.yml` files.

This is taken from travis-ci/travis.rb#307 which has been left to languish on the vine by the `travis.rb` maintainers.