### PR TITLE
Add optimize-png-hooks to list

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -187,3 +187,4 @@
 - https://github.com/chrismgrayftsinc/jsonnetfmt
 - https://github.com/zricethezav/gitleaks
 - https://github.com/hugoh/pre-commit-fish
+- https://github.com/redwarp/optimize-png-hooks


### PR DESCRIPTION
This hook runs on png files, using oxipng to optimize pngs in a predictable manner.
Requires rust.