### PR TITLE
 log_file description

### DIFF
--- a/sections/plugins.md
+++ b/sections/plugins.md
@@ -160,8 +160,8 @@ repository's configuration.
         the hook passes.  _new in 1.6.0_.
 =r=
     =c= [`log_file`](_#config-log_file)
-    =c= (optional) if present, the hook output will additionally be written
-        to a file.
+    =c= (optional) if present, the hook output will additionally be written to
+        a file when the hook fails or [verbose](#config-verbose) is `true`.
 ```
 
 One example of a complete configuration:


### PR DESCRIPTION
PR #376 included this clarification to the log_file parameter but was rejected because it included other unnecessary formatting changes.