### PR TITLE
add pre-commit-license-checks to the list of available hooks

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -188,3 +188,4 @@
 - https://github.com/zricethezav/gitleaks
 - https://github.com/hugoh/pre-commit-fish
 - https://github.com/redwarp/optimize-png-hooks
+- https://github.com/nbyl/pre-commit-license-checks


### PR DESCRIPTION
Here are two hooks to check the used licenses in a project against a dedicated allow list. 