### PR TITLE
Make filtering by hook type use element wise check instead of substring match

### DIFF
--- a/assets/filter_repos.js
+++ b/assets/filter_repos.js
@@ -20,7 +20,7 @@
                 for (let j = 0; j < repoHooks.length; j += 1) {
                     const repoHook = repoHooks[j];
                     const hookId = repoHook.dataset.id.toLowerCase();
-                    const hookTypes = repoHook.dataset.types;
+                    const hookTypes = repoHook.dataset.types.split(', ');
 
                     if (hookId.includes(id) && hookTypes.includes(type)) {
                         repoHook.hidden = false;


### PR DESCRIPTION
I just checked, which `tex` hooks are available on the website. It seems that filtering on `tex` also shows all the results for `text`. The list is almost identical between the two types.

If I understand the code correctly `hookTypes` is something like `shell, non-executable`. By splitting it on `', '` the `includes` check will work element wise instead of performing a substring match.