### PR TITLE
Fix broken search after #512

### DIFF
--- a/assets/filter_repos.js
+++ b/assets/filter_repos.js
@@ -22,7 +22,7 @@
                     const hookId = repoHook.dataset.id.toLowerCase();
                     const hookTypes = repoHook.dataset.types.split(', ');
 
-                    if (hookId.includes(id) && hookTypes.includes(type)) {
+                    if (hookId.includes(id) && (type === '' || hookTypes.includes(type))) {
                         repoHook.hidden = false;
                         hasVisibleHooks = true;
                     } else {


### PR DESCRIPTION
If `type` equals the empty string, no type filter should be applied.

Closes #520