### PR TITLE
Add snakefmt for Snakemake files

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -192,3 +192,4 @@
 - https://github.com/jonasbb/pre-commit-latex-hooks
 - https://github.com/dfm/black_nbconvert
 - https://github.com/crate-ci/typos
+- https://github.com/snakemake/snakefmt


### PR DESCRIPTION
I'm not a Snakemake or snakefmt author, but saw that they have a setup at https://github.com/snakemake/snakefmt/blob/master/.pre-commit-hooks.yaml and it wasn't in the list.