### PR TITLE
Re-enable skjold.

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -121,7 +121,7 @@
 - https://github.com/dmitri-lerko/pre-commit-docker-kustomize
 - https://github.com/perltidy/perltidy
 - https://github.com/talos-systems/conform
-# - https://github.com/twu/skjold
+- https://github.com/twu/skjold
 - https://github.com/commitizen-tools/commitizen
 - https://github.com/gherynos/pre-commit-java
 # - https://github.com/JamesWoolfenden/pre-commit


### PR DESCRIPTION
I removed `verbose` as per your [comment](https://github.com/twu/skjold/pull/48#discussion_r655524560) with [v0.3.2](https://github.com/twu/skjold/releases/tag/v0.3.2). Apologies for (unintentionally) breaking things. 🙇 

**Proposed Changes**:
- Re-enable `twu/skjold` in `all-hooks.yaml`.
