### PR TITLE
Add pre-commit-xmllint

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -193,3 +193,4 @@
 - https://github.com/dfm/black_nbconvert
 - https://github.com/crate-ci/typos
 - https://github.com/snakemake/snakefmt
+- https://github.com/lsst-ts/pre-commit-xmllint


### PR DESCRIPTION
Allows checks with output of xmllint --format. Reuquires xmlling (part of libxml) binary.