### PR TITLE
Add the repository `detect-direct-checkins`

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -196,3 +196,4 @@
 - https://github.com/regebro/pyroma
 - https://github.com/tox-dev/tox-ini-fmt
 - https://github.com/janosh/format-ipy-cells
+- https://github.com/IngoMeyer441/detect-direct-checkins


### PR DESCRIPTION
The `detect-direct-checkins` hook checks if configured branches contain
only merge commits (-> commits with two or more parents).

This check is similar to the official `no-commit-to-branch` hook but
allows the creation of merge commits. Fixes [issue 574 in the 
pre-commit-hooks repository](https://github.com/pre-commit/pre-commit-hooks/issues/574).