### PR TITLE
all-repos.yaml add format-ipy-cells hook

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -195,3 +195,4 @@
 - https://github.com/snakemake/snakefmt
 - https://github.com/regebro/pyroma
 - https://github.com/tox-dev/tox-ini-fmt
+- https://github.com/janosh/format-ipy-cells


### PR DESCRIPTION
Code formatter for cell delimiters in interactive iPython notebooks (`# %%`).