### PR TITLE
Add jekyll-relative-url-hook

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -199,3 +199,4 @@
 - https://github.com/FalcoSuessgott/lint-gitlab-ci
 - https://github.com/comkieffer/xml-linter-hook
 - https://github.com/jackdewinter/pymarkdown
+- https://github.com/klieret/jekyll-relative-url-check


### PR DESCRIPTION
I've created a hook for Jekyll websites that checks whether absolute links `[absolute link](/absolute/paths)` are used, rather than `[absolute link]({{site.baseurl}}/relative/path)` or similar constructs. More information is in the readme.