### PR TITLE
Fix gitlab-ci cache example

### DIFF
--- a/sections/advanced.md
+++ b/sections/advanced.md
@@ -738,7 +738,7 @@ See the [Gitlab caching best practices](https://docs.gitlab.com/ee/ci/caching/#g
 ```yaml
 my_job:
   variables:
-    PRE_COMMIT_HOME: ${CI_PROJECT_DIR}/.cache/pre-commit
+    PRE_COMMIT_HOME: ${CI_PROJECT_DIR}/.cache/pre-commit/
   cache:
     paths:
       - ${PRE_COMMIT_HOME}


### PR DESCRIPTION
Add a trailing slash to the `PRE_COMMIT_HOME` variable so that gitlab-ci caches correctly