### PR TITLE
chore: add clang-format-precommit

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -200,3 +200,4 @@
 - https://github.com/comkieffer/xml-linter-hook
 - https://github.com/jackdewinter/pymarkdown
 - https://github.com/klieret/jekyll-relative-url-check
+- https://github.com/ssciwr/clang-format-precommit


### PR DESCRIPTION
Uses 1-2 MB PyPI package on all platforms.

Let me know if there's any special ordering you'd like, just stuck it at the end.