### PR TITLE
Add sirosen/fix-ligatures to all-repos

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -162,6 +162,7 @@
 - https://github.com/PrincetonUniversity/blocklint
 - https://github.com/sirosen/check-jsonschema
 - https://github.com/sirosen/fix-smartquotes
+- https://github.com/sirosen/fix-ligatures
 - https://github.com/snok/pep585-upgrade
 - https://github.com/jendrikseipp/vulture
 - https://github.com/mwouts/jupytext


### PR DESCRIPTION
I ran into some annoying cases of ligature-ized text at work. e.g.
```diff
-conﬁgure
+configure
```

(Gross, eh?)

So I packaged up a fixer as a pre-commit hook! 😄 