### PR TITLE
Add a clang-format (pip) pre-commit hook

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -202,3 +202,4 @@
 - https://github.com/jackdewinter/pymarkdown
 - https://github.com/klieret/jekyll-relative-url-check
 - https://github.com/tarioch/flux-check-hook
+- https://github.com/ssciwr/clang-format-hook


### PR DESCRIPTION
* Adds a new pre-commit clang-format hook that uses a pip wheel so it's usable on pre-commit CI and doesn't require any external system level dependencies.