### PR TITLE
Set Git merge=union for all-repos.yaml

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+all-repos.yaml merge=union


### PR DESCRIPTION
This should prevent conflicts from parallel PR’s like in #580. We’ve done this for [Django’s release notes](https://github.com/django/django/blob/12fe3224f5086161462faf614cad91f3fad32e78/.gitattributes#L7) for a while.