### PR TITLE
Add `texthooks` project, remove hooks it replaces

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -162,8 +162,7 @@
 - https://github.com/ecugol/pre-commit-hooks-django
 - https://github.com/PrincetonUniversity/blocklint
 - https://github.com/sirosen/check-jsonschema
-- https://github.com/sirosen/fix-smartquotes
-- https://github.com/sirosen/fix-ligatures
+- https://github.com/sirosen/texthooks
 - https://github.com/snok/pep585-upgrade
 - https://github.com/jendrikseipp/vulture
 - https://github.com/mwouts/jupytext


### PR DESCRIPTION
I have a couple of hooks which I just consolidated into a single project. This removes my old ones and adds the replacement.

`texthooks` includes a hook which relates to https://github.com/pre-commit/pre-commit-hooks/issues/683, `forbid-bidi-controls`. I disagree about the utility of this hook, but respect the decision not to include it in that repo. Pursuing it on my own seemed best.