### PR TITLE
Add scop/pre-commit-shfmt

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -201,3 +201,4 @@
 - https://github.com/norwoodj/helm-docs
 - https://github.com/sqlfluff/sqlfluff
 - https://github.com/adamchainz/pre-commit-dprint
+- https://github.com/scop/pre-commit-shfmt


### PR DESCRIPTION
The major difference of this compared to other shfmt hooks listed here is that this one actually installs shfmt (or uses a Docker
image, user's choice), whereas others currently here require it to be installed separately.