### PR TITLE
Add nozaq/pre-commit-deno

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -202,3 +202,4 @@
 - https://github.com/sqlfluff/sqlfluff
 - https://github.com/adamchainz/pre-commit-dprint
 - https://github.com/scop/pre-commit-shfmt
+- https://github.com/nozaq/pre-commit-deno


### PR DESCRIPTION
This implements pre-commit-hooks for [Deno](https://deno.land/) projects.