### PR TITLE
Add gersemi CMake formatter

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -203,3 +203,4 @@
 - https://github.com/sqlfluff/sqlfluff
 - https://github.com/adamchainz/pre-commit-dprint
 - https://github.com/scop/pre-commit-shfmt
+- https://github.com/BlankSpruce/gersemi


### PR DESCRIPTION
Anticipating question "Why `require_serial: true`?" here's rationale: gersemi already spawns additional processes to do the formatting faster in case of multiple files.