### PR TITLE
Add check-json5 to all-repos.yaml

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -205,4 +205,4 @@
 - https://github.com/scop/pre-commit-shfmt
 - https://github.com/BlankSpruce/gersemi
 - https://github.com/realm/SwiftLint
-- https://gitlab.com/bmares/pre-commit-check-json5
+- https://gitlab.com/bmares/check-json5

--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -205,3 +205,4 @@
 - https://github.com/scop/pre-commit-shfmt
 - https://github.com/BlankSpruce/gersemi
 - https://github.com/realm/SwiftLint
+- https://gitlab.com/bmares/pre-commit-check-json5


### PR DESCRIPTION
This is just like `check-json` from the official hooks, but it tries to load a file with [`json5`](https://pypi.org/project/json5/) instead of the builtin [`json`](https://docs.python.org/3/library/json.html). The [JSON5 spec](https://json5.org/) allows for comments, trailing commas, and more.