### PR TITLE
Fix typo in new-hooks.md

### DIFF
--- a/sections/new-hooks.md
+++ b/sections/new-hooks.md
@@ -46,7 +46,7 @@ file that tells pre-commit:
     =c= (optional: default `false`) if `true` this hook will run even if there
         are no matching files.
 =r=
-    =c= [`fail_fast`'](_#hooks-fail_fast)
+    =c= [`fail_fast`](_#hooks-fail_fast)
     =c= (optional: default `false`) if `true` pre-commit will stop running
         hooks if this hook fails.  _new in 2.16.0_.
 =r=


### PR DESCRIPTION
Remove the unnecessary `'` symbol