### PR TITLE
Add cirlceci orb validation to all-repos

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -209,3 +209,4 @@
 - https://github.com/semaphor-dk/dansabel
 - https://github.com/adamchainz/pre-commit-oxipng
 - https://github.com/gitguardian/gg-shield
+- https://github.com/bjd2385/circleci-orb-pre-commit-hook


### PR DESCRIPTION
Adds a circleci orb pack and validation hook I've just written to the all-repos list.