### PR TITLE
Black version updated

### DIFF
--- a/sections/install.md
+++ b/sections/install.md
@@ -64,7 +64,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 19.3b0
+    rev: 21.12b0
     hooks:
     -   id: black
 ```


### PR DESCRIPTION
Black used to have a problem with [assignment expression](https://github.com/psf/black/pull/1655). Now the docs provide a black version that won't break.