### PR TITLE
Add apeschar/pre-commit-phan to all-repos.yaml

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -209,3 +209,4 @@
 - https://github.com/semaphor-dk/dansabel
 - https://github.com/adamchainz/pre-commit-oxipng
 - https://github.com/gitguardian/gg-shield
+- https://github.com/apeschar/pre-commit-phan


### PR DESCRIPTION
This PR adds apeschar/pre-commit-phan to the list of hooks, so that users can easily add [Phan](https://github.com/phan/phan) to their pre-commit checks.