### PR TITLE
Swap oxipng mirror for source repository

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -207,6 +207,6 @@
 - https://github.com/realm/SwiftLint
 - https://gitlab.com/bmares/check-json5
 - https://github.com/semaphor-dk/dansabel
-- https://github.com/adamchainz/pre-commit-oxipng
 - https://github.com/gitguardian/gg-shield
 - https://github.com/JohnnyMorganz/StyLua
+- https://github.com/shssoichiro/oxipng


### PR DESCRIPTION
The upstream repo merged a `.pre-commit-hooks.yaml` file, so the mirror is no longer required. Noted in mirror docs: https://github.com/adamchainz/pre-commit-oxipng#deprecated-2022-01-15