### PR TITLE
Add documentation about Lua language support.

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -87,6 +87,7 @@
 - https://github.com/homebysix/pre-commit-macadmin
 - https://github.com/fortman/pre-commit-prometheus
 - https://github.com/syntaqx/git-hooks
+- https://github.com/lunarmodules/luacheck
 - https://github.com/Calinou/pre-commit-luacheck
 - https://github.com/belminf/pre-commit-chef
 - https://github.com/pocc/pre-commit-hooks

--- a/sections/new-hooks.md
+++ b/sections/new-hooks.md
@@ -150,6 +150,7 @@ Hello from foo hook!
 - [dotnet](#dotnet)
 - [fail](#fail)
 - [golang](#golang)
+- [lua](#lua)
 - [node](#node)
 - [perl](#perl)
 - [python](#python)
@@ -312,6 +313,15 @@ the [`entry`](#hooks-entry) should match an executable which will get installed 
 
 __Support:__ golang hooks are known to work on any system which has go
 installed.  It has been tested on linux, macOS, and windows.
+
+### lua
+
+_new in 2.17.0_
+
+Lua hooks are installed with the version of Lua that is used by Luarocks.
+
+__Support:__ Lua hooks are known to work on any system which has Luarocks
+installed.  It has been tested on linux and macOS and _may_ work on windows.
 
 ### node
 


### PR DESCRIPTION
This branch adds a bit of documentation about the recently merged Lua support. I also added the hook repo for luacheck since that PR was merged with https://github.com/lunarmodules/luacheck/pull/48.

I would like to add the LuaFormatter to this PR, but that PR (https://github.com/Koihik/LuaFormatter/pull/236) has not been merged yet. Since the next version of pre-commit is not out yet, there may be time to slip that in before the next version of pre-commit is released.