### PR TITLE
Add the LuaFormatter hook definition from the canonical repo.

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -88,7 +88,7 @@
 - https://github.com/fortman/pre-commit-prometheus
 - https://github.com/syntaqx/git-hooks
 - https://github.com/lunarmodules/luacheck
-  https://github.com/Koihik/LuaFormatter
+- https://github.com/Koihik/LuaFormatter
 - https://github.com/Calinou/pre-commit-luacheck
 - https://github.com/belminf/pre-commit-chef
 - https://github.com/pocc/pre-commit-hooks

--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -88,6 +88,7 @@
 - https://github.com/fortman/pre-commit-prometheus
 - https://github.com/syntaqx/git-hooks
 - https://github.com/lunarmodules/luacheck
+  https://github.com/Koihik/LuaFormatter
 - https://github.com/Calinou/pre-commit-luacheck
 - https://github.com/belminf/pre-commit-chef
 - https://github.com/pocc/pre-commit-hooks


### PR DESCRIPTION
The hook using official Lua language support from 2.17.0 for LuaFormatter was merged upstream with https://github.com/Koihik/LuaFormatter/pull/236.

I'd like to add this to the list so that users have this as a visible option over the other hook that depends on the `system` mode.