### PR TITLE
Disable smooth scrolling

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -23,3 +23,5 @@ $code-color: #e83e8c !default;
 
 $lead-font-size: 1.75rem !default;
 $lead-font-weight: 400 !default;
+
+$enable-smooth-scroll: false;

--- a/scss/main_bs5.scss
+++ b/scss/main_bs5.scss
@@ -4,6 +4,28 @@
 // flush footer to bottom
 html {
     height: 100%;
+
+    // smooth scrolling only when clicking between sections.
+    animation: smoothscroll1 1s;
+
+    &:focus-within {
+        animation-name: smoothscroll2;
+        scroll-behavior: smooth;
+    }
+}
+
+@keyframes smoothscroll1 {
+    from,
+    to {
+        scroll-behavior: smooth;
+    }
+}
+
+@keyframes smoothscroll2 {
+    from,
+    to {
+        scroll-behavior: smooth;
+    }
 }
 
 body {

--- a/scss/main_bs5.scss
+++ b/scss/main_bs5.scss
@@ -4,28 +4,6 @@
 // flush footer to bottom
 html {
     height: 100%;
-
-    // smooth scrolling only when clicking between sections.
-    animation: smoothscroll1 1s;
-
-    &:focus-within {
-        animation-name: smoothscroll2;
-        scroll-behavior: smooth;
-    }
-}
-
-@keyframes smoothscroll1 {
-    from,
-    to {
-        scroll-behavior: smooth;
-    }
-}
-
-@keyframes smoothscroll2 {
-    from,
-    to {
-        scroll-behavior: smooth;
-    }
 }
 
 body {


### PR DESCRIPTION
I went to the pre-commit docs to try to find the details of the `fail` language and noticed that searching the page uses a smooth scroll animation which is pretty slow and a bit nausea-inducing:


https://user-images.githubusercontent.com/665269/151456067-3caad462-691d-4c4a-87c8-d44ba207ddc7.mov


I found a fix here which keeps the smooth scrolling when navigating between sections but not when using Ctrl-F to search: https://schepp.dev/posts/smooth-scrolling-and-page-search/

The CSS is a little bit complex, I'm happy to delete this PR if you don't care enough (or just turn off all smooth scrolling if you prefer).