### PR TITLE
Black is no longer a beta product

### DIFF
--- a/sections/install.md
+++ b/sections/install.md
@@ -64,7 +64,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.1.0
     hooks:
     -   id: black
 ```


### PR DESCRIPTION
Black is no longer a beta product, setting black rev to 22.1.0.

https://github.com/psf/black/releases/tag/22.1.0