### PR TITLE
Add REUSE tool

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -214,3 +214,4 @@
 - https://github.com/shssoichiro/oxipng
 - https://github.com/datarootsio/databooks
 - https://github.com/standard/standard
+- https://git.fsfe.org/reuse/tool


### PR DESCRIPTION
Add a new hook to the list: this one verifies the presence machine-readable license information.

Note: I am linking to fsfe.org instead of GitHub because https://reuse.software/dev/#tool links to https://git.fsfe.org/reuse/tool (click on the "REUSE helper tool" link)