### PR TITLE
Update the home of 'check-jsonschema'

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -159,7 +159,7 @@
 - https://github.com/mgedmin/check-manifest
 - https://github.com/ecugol/pre-commit-hooks-django
 - https://github.com/PrincetonUniversity/blocklint
-- https://github.com/sirosen/check-jsonschema
+- https://github.com/python-jsonschema/check-jsonschema
 - https://github.com/sirosen/texthooks
 - https://github.com/snok/pep585-upgrade
 - https://github.com/jendrikseipp/vulture


### PR DESCRIPTION
This rename is one of the reasons for my interest in https://github.com/pre-commit/pre-commit-hooks/issues/726 . It would be nice to somehow get this update into consuming repos.

The plan is to move the `jsonschema` lib into `python-jsonschema` and make this the pre-commit hook for any `jsonschema` usage.

... Anywho, this is just a rename! 😄 