### PR TITLE
A linter for Sceptre stack configs

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -214,3 +214,4 @@
 - https://github.com/shssoichiro/oxipng
 - https://github.com/datarootsio/databooks
 - https://github.com/standard/standard
+- https://github.com/Sceptre/sceptrelint


### PR DESCRIPTION
Add a reference to the Sceptre pre-commit linter.  This linter checks
sceptre stack configurations[1]

[1] https://docs.sceptre-project.org/dev/docs/stack_config.html