### PR TITLE
Document issue with gitlab non-constant build location

### DIFF
--- a/sections/advanced.md
+++ b/sections/advanced.md
@@ -743,7 +743,7 @@ my_job:
 ```
 
 pre-commit's cache requires to be served from a constant location between the different builds. This isn't the default when using k8s runners
-on Gitlab. In case you face the error `InvalidManifestError`, set `builds_dir` to something static e.g `builds_dir = "/builds"` in your `[[runner]]` config
+on GitLab. In case you face the error `InvalidManifestError`, set `builds_dir` to something static e.g `builds_dir = "/builds"` in your `[[runner]]` config
 
 ### travis-ci example
 

--- a/sections/advanced.md
+++ b/sections/advanced.md
@@ -742,6 +742,9 @@ my_job:
       - ${PRE_COMMIT_HOME}
 ```
 
+pre-commit's cache requires to be served from a constant location between the different builds. This isn't the default when using k8s runners
+on Gitlab. In case you face the error `InvalidManifestError`, set `builds_dir` to something static e.g `builds_dir = "/builds"` in your `[[runner]]` config
+
 ### travis-ci example
 
 ```yaml


### PR DESCRIPTION
Document issue with gitlab non-constant build location that clashes with pre-commit's cache that expects a constant location.

This relates to https://github.com/pre-commit/pre-commit/issues/1133#issuecomment-985053269