### PR TITLE
added latexindent.pl to all-repos.yaml

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -217,3 +217,4 @@
 - https://github.com/Sceptre/sceptrelint
 - https://github.com/lyz-code/yamlfix
 - https://github.com/dannysepler/rm_unneeded_f_str
+- https://github.com/cmhughes/latexindent.pl


### PR DESCRIPTION
Thanks for the `pre-commit` tool.

This pull request adds `https://github.com/cmhughes/latexindent.pl` to the all-repos.yaml file. I hope this is the appropriate place, let me know if not.