### PR TITLE
Consistent use of indentation in yaml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,20 +1,21 @@
+---
 name: deploy
 on:
   pull_request:
   push:
     branches: [main]
   schedule:
-    - cron: '30 8 * * *'
+    - cron: 30 8 * * *
 
 jobs:
   build:
     name: pr
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
-    - run: pip install virtualenv
-    - run: make
-    - run: make push
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+      - run: pip install virtualenv
+      - run: make
+      - run: make push
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,55 +1,56 @@
+---
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.2.0
     hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-yaml
-    -   id: debug-statements
-    -   id: double-quote-string-fixer
-    -   id: name-tests-test
-    -   id: requirements-txt-fixer
--   repo: https://github.com/asottile/reorder_python_imports
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: debug-statements
+      - id: double-quote-string-fixer
+      - id: name-tests-test
+      - id: requirements-txt-fixer
+  - repo: https://github.com/asottile/reorder_python_imports
     rev: v3.1.0
     hooks:
-    -   id: reorder-python-imports
-        args: [--py37-plus, --add-import, 'from __future__ import annotations']
+      - id: reorder-python-imports
+        args: [--py37-plus, --add-import, from __future__ import annotations]
         exclude: ^install-local.py$
-    -   id: reorder-python-imports
+      - id: reorder-python-imports
         files: ^install-local.py$
--   repo: https://github.com/asottile/add-trailing-comma
+  - repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.3
     hooks:
-    -   id: add-trailing-comma
+      - id: add-trailing-comma
         args: [--py36-plus]
--   repo: https://github.com/asottile/pyupgrade
+  - repo: https://github.com/asottile/pyupgrade
     rev: v2.32.1
     hooks:
-    -   id: pyupgrade
+      - id: pyupgrade
         args: [--py37-plus]
         exclude: ^install-local.py$
--   repo: https://github.com/pre-commit/mirrors-autopep8
+  - repo: https://github.com/pre-commit/mirrors-autopep8
     rev: v1.6.0
     hooks:
-    -   id: autopep8
--   repo: https://github.com/PyCQA/flake8
+      - id: autopep8
+  - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
-    -   id: flake8
--   repo: https://github.com/pre-commit/mirrors-mypy
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.950
     hooks:
-    -   id: mypy
+      - id: mypy
         additional_dependencies: [types-all]
--   repo: https://github.com/pre-commit/mirrors-eslint
+  - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v8.15.0
     hooks:
-    -   id: eslint
+      - id: eslint
         args: [--fix]
--   repo: local
+  - repo: local
     hooks:
-    -   id: no-github-dot-git
+      - id: no-github-dot-git
         name: No need for .git for github/gitlab urls
-        entry: '(github|gitlab).*\.git'
+        entry: (github|gitlab).*\.git
         files: all-repos.yaml
         language: pygrep

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,35 +1,36 @@
+---
 linters:
-    BorderZero:
-        enabled: false
-    ColorKeyword:
-        enabled: false
-    ColorVariable:
-        enabled: false
-    Comment:
-        enabled: false
-    DeclarationOrder:
-        enabled: false
-    DuplicateProperty:
-        enabled: false
-    IdWithExtraneousSelector:
-        enabled: false
-    Indentation:
-        width: 4
-    LeadingZero:
-        enabled: false
-    MergeableSelector:
-        force_nesting: false
-    NestingDepth:
-        max_depth: 4
-    PlaceholderInExtend:
-        enabled: false
-    PropertySortOrder:
-        enabled: false
-    SelectorDepth:
-        enabled: false
-    StringQuotes:
-        enabled: false
-    UrlFormat:
-        enabled: false
-    UrlQuotes:
-        enabled: false
+  BorderZero:
+    enabled: false
+  ColorKeyword:
+    enabled: false
+  ColorVariable:
+    enabled: false
+  Comment:
+    enabled: false
+  DeclarationOrder:
+    enabled: false
+  DuplicateProperty:
+    enabled: false
+  IdWithExtraneousSelector:
+    enabled: false
+  Indentation:
+    width: 4
+  LeadingZero:
+    enabled: false
+  MergeableSelector:
+    force_nesting: false
+  NestingDepth:
+    max_depth: 4
+  PlaceholderInExtend:
+    enabled: false
+  PropertySortOrder:
+    enabled: false
+  SelectorDepth:
+    enabled: false
+  StringQuotes:
+    enabled: false
+  UrlFormat:
+    enabled: false
+  UrlQuotes:
+    enabled: false

--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -1,3 +1,4 @@
+---
 # This file is used to generate all-hooks.json
 - https://github.com/pre-commit/pre-commit-hooks
 - https://github.com/pre-commit/mirrors-autopep8

--- a/sections/advanced.md
+++ b/sections/advanced.md
@@ -39,9 +39,9 @@ prevent the commit from happening (use `pre-commit` instead).  Since
 `post-commit` does not operate on files, any hooks must set `always_run`:
 
 ```yaml
--   repo: local
+  - repo: local
     hooks:
-    -   id: post-commit-local
+      - id: post-commit-local
         name: post commit
         always_run: true
         stages: [post-commit]
@@ -170,9 +170,9 @@ or set working dir metadata properties. Since `post-checkout` doesn't operate
 on files, any hooks must set `always_run`:
 
 ```yaml
--   repo: local
+  - repo: local
     hooks:
-    -   id: post-checkout-local
+      - id: post-checkout-local
         name: Post checkout
         always_run: true
         stages: [post-checkout]
@@ -241,10 +241,10 @@ arguments by specifying the [`args`](#config-args) property in your `.pre-commit
 as follows:
 
 ```yaml
--   repo: https://github.com/PyCQA/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
-    -   id: flake8
+      - id: flake8
         args: [--max-line-length=131]
 ```
 
@@ -258,10 +258,10 @@ the [`args`](#config-args) value and then a list of staged files.
 For example, assuming a `.pre-commit-config.yaml`:
 
 ```yaml
--   repo: https://github.com/path/to/your/hook/repo
+  - repo: https://github.com/path/to/your/hook/repo
     rev: badf00ddeadbeef
     hooks:
-    -   id: my-hook-script-id
+      - id: my-hook-script-id
         args: [--myarg1=1, --myarg1=2]
 ```
 
@@ -284,9 +284,9 @@ instead put your arguments directly in the hook [`entry`](#hooks-entry).
 For example:
 
 ```yaml
--   repo: local
+  - repo: local
     hooks:
-    -   id: check-requirements
+      - id: check-requirements
         name: check requirements files
         language: system
         entry: python -m scripts.check_requirements --compare
@@ -318,20 +318,20 @@ as specified under [Creating new hooks](#new-hooks).
 Here's an example configuration with a few `local` hooks:
 
 ```yaml
--   repo: local
+  - repo: local
     hooks:
-    -   id: pylint
+      - id: pylint
         name: pylint
         entry: pylint
         language: system
         types: [python]
         require_serial: true
-    -   id: check-x
+      - id: check-x
         name: Check X
         entry: ./bin/check-x.sh
         language: script
         files: \.x$
-    -   id: scss-lint
+      - id: scss-lint
         name: scss-lint
         entry: scss-lint
         language: ruby
@@ -348,9 +348,9 @@ _new in 1.4.0_
 pre-commit configuration itself.  These can be enabled using `repo: meta`.
 
 ```yaml
--   repo: meta
+  - repo: meta
     hooks:
-    -   id: ...
+      - id: ...
 ```
 
 The currently available `meta` hooks:
@@ -505,7 +505,7 @@ the `types` setting.  Here's an example of using `check-json` against non-json
 files:
 
 ```yaml
-    -   id: check-json
+      - id: check-json
         types: [file]  # override `types: [json]`
         files: \.(json|myext)$
 ```
@@ -532,7 +532,7 @@ the `(?x)` regex flag.
 
 ```yaml
 # ...
-    -   id: my-hook
+      - id: my-hook
         exclude: |
             (?x)^(
                 path/to/file1.py|
@@ -551,10 +551,10 @@ don’t want the default system installed version so you can override this on a
 per-hook basis by setting the [`language_version`](#config-language_version).
 
 ```yaml
--   repo: https://github.com/pre-commit/mirrors-scss-lint
+  - repo: https://github.com/pre-commit/mirrors-scss-lint
     rev: v0.54.0
     hooks:
-    -   id: scss-lint
+      - id: scss-lint
         language_version: 2.1.5
 ```
 

--- a/sections/cli.md
+++ b/sections/cli.md
@@ -28,14 +28,14 @@ Here are some sample invocations using this `.pre-commit-config.yaml`:
 
 ```yaml
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.1.0
     hooks:
-    -   id: trailing-whitespace
--   repo: https://github.com/asottile/pyupgrade
+      - id: trailing-whitespace
+  - repo: https://github.com/asottile/pyupgrade
     rev: v1.25.0
     hooks:
-    -   id: pyupgrade
+      - id: pyupgrade
         args: [--py36-plus]
 ```
 

--- a/sections/install.md
+++ b/sections/install.md
@@ -57,16 +57,16 @@ pre-commit --version
 
 ```yaml
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
     hooks:
-    -   id: check-yaml
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace
--   repo: https://github.com/psf/black
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/psf/black
     rev: 21.12b0
     hooks:
-    -   id: black
+      - id: black
 ```
 
 ### 3. Install the git hook scripts

--- a/sections/new-hooks.md
+++ b/sections/new-hooks.md
@@ -88,7 +88,7 @@ file that tells pre-commit:
 For example:
 
 ```yaml
--   id: trailing-whitespace
+  - id: trailing-whitespace
     name: Trim Trailing Whitespace
     description: This hook trims trailing whitespace.
     entry: trailing-whitespace-fixer
@@ -259,16 +259,16 @@ entrypoint you can specify it as well in your [`entry`](#hooks-entry).
 For example:
 
 ```yaml
--   id: dockerfile-provides-entrypoint
+  - id: dockerfile-provides-entrypoint
     name: ...
     language: docker_image
     entry: my.registry.example.com/docker-image-1:latest
--   id: dockerfile-no-entrypoint-1
+  - id: dockerfile-no-entrypoint-1
     name: ...
     language: docker_image
     entry: --entrypoint my-exe my.registry.example.com/docker-image-2:latest
 # Alternative equivalent solution
--   id: dockerfile-no-entrypoint-2
+  - id: dockerfile-no-entrypoint-2
     name: ...
     language: docker_image
     entry: my.registry.example.com/docker-image-3:latest my-exe
@@ -302,9 +302,9 @@ Here's an example which prevents any file except those ending with `.rst` from
 being added to the `changelog` directory:
 
 ```yaml
--   repo: local
+  - repo: local
     hooks:
-    -   id: changelogs-rst
+      - id: changelogs-rst
         name: changelogs must be rst
         entry: changelog filenames must end in .rst
         language: fail

--- a/sections/plugins.md
+++ b/sections/plugins.md
@@ -97,10 +97,10 @@ A sample repository:
 
 ```yaml
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v1.2.3
     hooks:
-    -   ...
+      - ...
 ```
 
 ## .pre-commit-config.yaml - hooks
@@ -175,10 +175,10 @@ One example of a complete configuration:
 
 ```yaml
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v1.2.3
     hooks:
-    -   id: trailing-whitespace
+      - id: trailing-whitespace
 ```
 
 This configuration says to download the pre-commit-hooks project and run its


### PR DESCRIPTION
## What is changed?
- YAML files have been formatted using `yamlfix` with it's default config.
- YAML in MD has been modified in a similar way to what `yamlfix` would have done, e.g. by placing 2 spaces before the dash that demarcates sequences, and only one behind.

## Why?
The YAML spec doesn't specify any particular number of spaces for indented blocks, but two space seem to be most common, and for sequences these spaces tend to be placed before the dash, with only a single space after. For instance, have a look at the official [GitHub Actions tutorial](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions), or the [GitLab docs](https://docs.gitlab.com/ee/ci/yaml/gitlab_ci_yaml.html). `yamllint` complains about "too many spaces after hyphen" when run against the current format, and `yamlfix` will go ahead and remove all but one space after each hyphen.

The examples in the pre-commit docs is an exception, and as a result, so are examples given by some other hook maintainers. This again results in `.pre-commit-config.yaml` files with mixed formatting, as some devs just paste examples they see online, while others change to the more common formatting. I think there is much higher probability to achieve a "consensus" around the `yamllint` / `yamlfix` indentation format than the one currently used here.
