### PR TITLE
Add ripsecrets to all-repos.yaml

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -218,3 +218,4 @@
 - https://github.com/lyz-code/yamlfix
 - https://github.com/dannysepler/rm_unneeded_f_str
 - https://github.com/cmhughes/latexindent.pl
+- https://github.com/sirwart/ripsecrets


### PR DESCRIPTION
I'd like to add ripsecrets to your list of repos supporting pre-commit. It helps prevent developers from accidentally checking secrets into their source code. Thanks!