### PR TITLE
Add renovatebot hooks repo

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -219,3 +219,4 @@
 - https://github.com/dannysepler/rm_unneeded_f_str
 - https://github.com/cmhughes/latexindent.pl
 - https://github.com/sirwart/ripsecrets
+- https://github.com/renovatebot/pre-commit-hooks


### PR DESCRIPTION
Adds [renovatebot/pre-commit-hooks](https://github.com/renovatebot/pre-commit-hooks) to the list.

You might wonder why it is not part of the main Renovate repository, it is because Renovate uses TypeScript which requires compiling to JS and `yarn` instead of `npm`, so a simple `npm install .` does not work there. And `yarn` still uses the `dependencies`/`devDependencies` keys in `package.json`, so we isolated it to avoid any interference when setting up the hook

Thank you!
