### PR TITLE
Add REUSE tool repository

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -219,3 +219,4 @@
 - https://github.com/dannysepler/rm_unneeded_f_str
 - https://github.com/cmhughes/latexindent.pl
 - https://github.com/sirwart/ripsecrets
+- https://github.com/fsfe/reuse-tool


### PR DESCRIPTION
The CLI tool of the https://reuse.software/ project already had a pre-commit hook for a while: https://github.com/fsfe/reuse-tool/blob/master/.pre-commit-hooks.yaml By adding it to the official list it will be more convenient for others to discover and adopt REUSE.