### PR TITLE
Add mz-lictools to the repos list

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -219,3 +219,4 @@
 - https://github.com/dannysepler/rm_unneeded_f_str
 - https://github.com/cmhughes/latexindent.pl
 - https://github.com/sirwart/ripsecrets
+- https://github.com/emzeat/mz-lictools


### PR DESCRIPTION
Provides pre-commit hooks to automagically manage the
license headers on source files.