### PR TITLE
Add another shellcheck pre-commit hook

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -219,3 +219,4 @@
 - https://github.com/dannysepler/rm_unneeded_f_str
 - https://github.com/cmhughes/latexindent.pl
 - https://github.com/sirwart/ripsecrets
+- https://github.com/koalaman/shellcheck-precommit


### PR DESCRIPTION
This seems to be the official pre-commit hook for shellcheck. Reasons:
- It claims it
- It is from the same author as shellcheck