### PR TITLE
build: add asort

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -104,6 +104,7 @@
 - https://github.com/FelixSeptem/pre-commit-golang
 - https://gitlab.com/daverona/pre-commit/cpp
 - https://github.com/codingjoe/relint
+- https://github.com/cpendery/asort
 - https://github.com/nix-community/nixpkgs-fmt
 - https://github.com/d6e/beancount-check
 - https://gitlab.com/iamlikeme/nbhooks


### PR DESCRIPTION
## 📝 Description
Add support for `asort`, a python pip utility that keeps your `__all__` lists sorted. 