### PR TITLE
build: add github-issue-prefix commit msg

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -219,3 +219,4 @@
 - https://github.com/dannysepler/rm_unneeded_f_str
 - https://github.com/cmhughes/latexindent.pl
 - https://github.com/sirwart/ripsecrets
+- https://github.com/KimSoungRyoul/add-github-issue-prefix


### PR DESCRIPTION
## Description
[add-msg-issue-prefix-hook](https://github.com/avilaton/add-msg-issue-prefix-hook) is used only in Jira

[add-github-issue-prefix](https://github.com/KimSoungRyoul/add-github-issue-prefix) support commit msg prefix for github issue and provides more customizable options. 