### PR TITLE
Add cpp-linter-hooks to the all-repos list

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -219,3 +219,4 @@
 - https://github.com/dannysepler/rm_unneeded_f_str
 - https://github.com/cmhughes/latexindent.pl
 - https://github.com/sirwart/ripsecrets
+- https://github.com/cpp-linter/cpp-linter-hooks


### PR DESCRIPTION
Thanks for creating such a great framework.

I know there are already hooks that support `clang-format` and `clang-tidy`, but I still want to recommend this hook because:

1. It supports users to use any specific versions of `clang-format` and `clang-tidy` (from v3.9 to v14)
2. `clang-format` and `clang-tidy` binares can be automatically installed on Windows, Linux, and macOS if they do not exist.