### PR TITLE
Add compilerla/conventional-pre-commit to all-repos.yaml

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -230,3 +230,4 @@
 - https://github.com/jshwi/docsig
 - https://github.com/finsberg/clang-format-docs
 - https://github.com/rubocop/rubocop
+- https://github.com/compilerla/conventional-pre-commit


### PR DESCRIPTION
This closes compilerla/conventional-pre-commit#24.

~@asottile I saw [your comment in #684](https://github.com/pre-commit/pre-commit.com/pull/684#issuecomment-1184377808)~

~> `language: script` hooks miss the point of the framework as they require users to install tools outside of the framework to use them and as such I'm not allowing new ones onto the hooks page~

~And while `conventional-pre-commit` is a `language: script` hook, it's literally just a [small shell script](https://github.com/compilerla/conventional-pre-commit/blob/main/conventional-pre-commit.sh) that does some regex against the commit message, no external tools/dependencies installed or needed. Maybe an exception can be made in this case?~

Python hook that checks for [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format, intended to run in the `commit-msg` stage.

Thanks for taking a look!

___

<!-- if your edit is to something other than all-repos.yaml remove this -->

my new repository:

- [x] is added to the bottom *or* with existing repos from the same account
- [x] contains a license
- [x] is not `language: system` or `language: docker`
- [ ] does not contain "pre-commit" in the name
