### PR TITLE
Add hooks for `shellcheck` & `vale`

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -221,3 +221,5 @@
 - https://github.com/sirwart/ripsecrets
 - https://github.com/bagerard/graphviz-dot-hooks
 - https://github.com/omnilib/ufmt
+- https://github.com/Jarmos-san/vale-precommit
+- https://github.com/Jarmos-san/shellcheck-precommit


### PR DESCRIPTION
Add a couple more hooks. More information are as follows:

- `shellcheck-precommit` is an improved unofficial version of [koalaman/shellcheck-precommit](https://github.com/koalaman/shellcheck-precommit). The improved version doesn't require a build phase & instead uses the installed `shellcheck` binary.
- `vale-precommit` is a linter for checking grammatical/spelling errors in prose like content written in Markdown & Plan Text files.