### PR TITLE
Add conhead consistent headers pre-commit hook

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -221,3 +221,4 @@
 - https://github.com/sirwart/ripsecrets
 - https://github.com/bagerard/graphviz-dot-hooks
 - https://github.com/omnilib/ufmt
+- https://github.com/slobberchops/conhead


### PR DESCRIPTION
conhead (short for consistent headers) is a tool that is useful for adding headers to files (typically license headers) and keeping them up to date (maintaining copyright years over time). It is available as a pre-commit hook.