### PR TITLE
Add checkstyle-cli

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -221,3 +221,4 @@
 - https://github.com/sirwart/ripsecrets
 - https://github.com/bagerard/graphviz-dot-hooks
 - https://github.com/omnilib/ufmt
+- https://github.com/junghoon-vans/checkstyle-cli


### PR DESCRIPTION
`checkstyle-cli` is a command-line tool for checkstyle(static analysis tool for java)