### PR TITLE
Add buildifier pre-commit hook

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -221,3 +221,4 @@
 - https://github.com/sirwart/ripsecrets
 - https://github.com/bagerard/graphviz-dot-hooks
 - https://github.com/omnilib/ufmt
+- https://github.com/Warchant/pre-commit-buildifier


### PR DESCRIPTION
Buildifier is a linter/formatter for Bazel files (.bzl, BUILD, WORKSPACE).