### PR TITLE
Add scop/pre-commit-perlcritic

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -205,6 +205,7 @@
 - https://github.com/sqlfluff/sqlfluff
 - https://github.com/adamchainz/pre-commit-dprint
 - https://github.com/scop/pre-commit-shfmt
+- https://github.com/scop/pre-commit-perlcritic
 - https://github.com/BlankSpruce/gersemi
 - https://github.com/realm/SwiftLint
 - https://gitlab.com/bmares/check-json5


### PR DESCRIPTION
The major difference of this compared to the henryykt/pre-commit-perl one is that this one actually installs perlcritic, whereas the other requires it to be installed separately.