### PR TITLE
clarify autoupdate selection logic

### DIFF
--- a/sections/cli.md
+++ b/sections/cli.md
@@ -15,9 +15,12 @@ _new in 2.8.0_: `pre-commit` now exits with more specific codes:
 
 Auto-update pre-commit config to the latest repos' versions.
 
+By default, pre-commit will choose the latest tag on the repository's default
+branch, preferentially picking a tag that contains a `.` in the case of ties.
+
 Options:
 
-- `--bleeding-edge`: update to the bleeding edge of the default branch instead
+- `--bleeding-edge`: update to the latest commit of the default branch instead
   of the latest tagged version (the default behaviour).
 - `--freeze`: _new in 1.21.0_: Store "frozen" hashes in [`rev`](#repos-rev)
   instead of tag names.
@@ -66,6 +69,16 @@ Updating https://github.com/asottile/pyupgrade ... updating v1.25.0 -> v1.25.2 (
 $ grep rev: .pre-commit-config.yaml
     rev: 0161422b4e09b47536ea13f49e786eb3616fe0d7  # frozen: v2.4.0
     rev: 34a269fd7650d264e4de7603157c10d0a9bb8211  # frozen: v1.25.2
+```
+
+You can check what the latest tag on the default branch of any repository is,
+you can do the following (using the pre-commit-hooks repository as an example):
+
+```console
+$ git clone --quiet https://github.com/pre-commit/pre-commit-hooks
+$ cd pre-commit-hooks
+$ git describe --tags --abbrev=0
+v2.4.0
 ```
 
 _new in 2.18.0_: pre-commit will preferentially pick tags containing a `.` if


### PR DESCRIPTION
When reporting an issue on pre-commit earlier, I had misunderstood what the selection logic was for the "latest" tag to be updated to. When I was directed to the manual, it wasn't immediately apparent to me what I had misunderstood. I suspect that this is because the manual is clear and concise to the repository maintainers who are familiar with the code but doesn't give enough context to those of us who are just mere users of the tool.

I'd like to propose the following additions to the `autoupdate` section of the docs, to help clarify the logic of which tag is chosen. Hopefully this change will result in fewer erroneous bug reports and also provide more clarity to people who are directed to the docs in response to a github issue.

I considered adding a note about the fact that git tag dates are not available within git repositories (they're a feature of github and its api) as I had found this confusion from another user in a different issue... but I chose to leave it out as I felt that the docs can't possibly answer _every_ permutation of the question and it was better to keep things brief for the general case.