### PR TITLE
Update install.md

### DIFF
--- a/sections/install.md
+++ b/sections/install.md
@@ -58,13 +58,13 @@ pre-commit --version
 ```yaml
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v4.3.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
     -   id: black
 ```


### PR DESCRIPTION
I propose to update the hooks version, but especially black: the specified version has a bug and create issues with new people trying to follow the steps installing pre-commit.

ref: https://github.com/psf/black/issues/2964