### PR TITLE
remove redwarp/optimize-png-hooks which sets `verbose: true`

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -185,7 +185,6 @@
 - https://github.com/chrismgrayftsinc/jsonnetfmt
 - https://github.com/zricethezav/gitleaks
 - https://github.com/hugoh/pre-commit-fish
-- https://github.com/redwarp/optimize-png-hooks
 - https://github.com/nbyl/pre-commit-license-checks
 - https://github.com/jonasbb/pre-commit-latex-hooks
 - https://github.com/dfm/black_nbconvert


### PR DESCRIPTION
cc @redwarp -- seems this was intentional deprecation 👍 