### PR TITLE
Remove `kintoandar/pre-commit`

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -52,7 +52,6 @@
 - https://github.com/doublify/pre-commit-go
 - https://github.com/doublify/pre-commit-hindent
 - https://github.com/doublify/pre-commit-rust
-- https://github.com/kintoandar/pre-commit
 - https://github.com/awebdeveloper/pre-commit-stylelint
 - https://github.com/awebdeveloper/pre-commit-tslint
 - https://github.com/adrienverge/yamllint


### PR DESCRIPTION
`terraform_validate` hook doesn't work. I've opened the ticket with the problem description but it seems authot decided to archive the repository. So, I think it is better to remove it from the "pre-commit hooks" page.

**Reference**

https://github.com/kintoandar/pre-commit/issues/9