### PR TITLE
Add qarik-group/gitlab-codeowners-linter

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -219,3 +219,4 @@
 - https://github.com/sirwart/ripsecrets
 - https://github.com/bagerard/graphviz-dot-hooks
 - https://github.com/omnilib/ufmt
+- https://github.com/Qarik-Group/gitlab-codeowners-linter


### PR DESCRIPTION
`qarik-group/gitlab-codeowners-linter` is a linter for [Gitlab's CODEOWNERS file](https://docs.gitlab.com/ee/user/project/code_owners.html). Note that the syntax for Gitlab is different than Github's one so linters like `github.com/milin/gitown` are not compatible.