### PR TITLE
Add MacPorts installation instructions

### DIFF
--- a/sections/install.md
+++ b/sections/install.md
@@ -28,6 +28,12 @@ Using [homebrew](https://brew.sh):
 brew install pre-commit
 ```
 
+Using [MacPorts](https://ports.macports.org/port/pre-commit/):
+
+```bash
+sudo port install pre-commit
+```
+
 Using [conda](https://conda.io) (via [conda-forge](https://conda-forge.org)):
 
 ```bash


### PR DESCRIPTION
You can [install pre-commit using MacPorts](https://ports.macports.org/port/pre-commit/)! This PR adds this information to the install documentation.