### PR TITLE
Add cython-lint to list of hooks

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -169,6 +169,7 @@
 - https://github.com/guid-empty/flutter-dependency-validation-pre-commit
 - https://github.com/cpplint/cpplint
 - https://github.com/MarcoGorelli/absolufy-imports
+- https://github.com/MarcoGorelli/cython-lint
 - https://github.com/domdfcoding/flake2lint
 - https://github.com/dotnet/format
 - https://github.com/ashwin153/pre-commit-vagrant


### PR DESCRIPTION
Something I've been working on https://github.com/MarcoGorelli/cython-lint, looks like it'd only be the second hook here (after isort) to run on cython files