### PR TITLE
Add python-unittest

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -220,3 +220,4 @@
 - https://github.com/bagerard/graphviz-dot-hooks
 - https://github.com/omnilib/ufmt
 - https://github.com/daveshanley/vacuum
+- https://github.com/sharkwouter/python-unittest


### PR DESCRIPTION
This is a very simple hook which runs `python3 -m unittest discover -qb`. The q and b are to silence any output a successful test might have, but errors are still shown.

The code for the hook can be found here: https://github.com/sharkwouter/python-unittest