### PR TITLE
badge: remove logoColor

### DIFF
--- a/sections/advanced.md
+++ b/sections/advanced.md
@@ -588,24 +588,24 @@ default_language_version:
 you can add a badge to your repository to show your contributors / users that
 you use pre-commit!
 
-[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 
 - Markdown:
 
   ```md#copyable
-  [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
+  [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
   ```
 
 - HTML:
 
   ```html#copyable
-  <a href="https://github.com/pre-commit/pre-commit"><img src="https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white" alt="pre-commit" style="max-width:100%;"></a>
+  <a href="https://github.com/pre-commit/pre-commit"><img src="https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit" alt="pre-commit" style="max-width:100%;"></a>
   ```
 
 - reStructuredText:
 
   ```rst#copyable
-  .. image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white
+  .. image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit
      :target: https://github.com/pre-commit/pre-commit
      :alt: pre-commit
   ```
@@ -613,7 +613,7 @@ you use pre-commit!
 - AsciiDoc:
 
   ```#copyable
-  image:https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white[pre-commit, link=https://github.com/pre-commit/pre-commit]
+  image:https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit[pre-commit, link=https://github.com/pre-commit/pre-commit]
   ```
 
 ## Usage in continuous integration


### PR DESCRIPTION
With a bit of delay: This PR removes the logoColor option for the shields.io badges. 

The double-escaping comes from `template_lib`, feel free to pull in https://github.com/pre-commit/pre-commit.com/compare/main...mhils:pre-commit.com:no-double-escape instead/as well if that makes sense for you.