### PR TITLE
add pre-commit-trailer and pre-commit-ssh-git-signing-key

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -222,3 +222,5 @@
 - https://github.com/omnilib/ufmt
 - https://github.com/daveshanley/vacuum
 - https://github.com/nuztalgia/botstrap
+- https://gitlab.com/adam-moss/pre-commit-trailer
+- https://gitlab.com/adam-moss/pre-commit-ssh-git-signing-key


### PR DESCRIPTION
adds pre-commit hooks to
- add a Pre-Commit-Config: trailer to commit messages on `commit-msg`
- add ssh based git signing key to ssh agent on `commit-msg`
- remove ssh based git signing key from ssh-agent on `post-commit`

Implemented as POSIX shell scripts for portability and simplicity.

In https://github.com/pre-commit/pre-commit.com/pull/684#issuecomment-1184377808 you state

> - `language: script` hooks miss the point of the framework as they require users to install tools outside of the framework to use them and as such I'm not allowing new ones onto the hooks page

I have raised this merge request for visibility and considerations of the `add-pre-commit-config-trailer` hook, which was mentioned in https://github.com/pre-commit/pre-commit/issues/582#issuecomment-1316032165 as a solution to an issue outstanding since 2017.

Anyone wanting to utilise these hooks would by definition already have the relevant tooling (`git` and `ssh`) installed so abstracting into python would simply increase the lines of code and associated dependency tree for no material gain.