### PR TITLE
Fix link to `default_install_hook_types` in `cli` section

### DIFF
--- a/sections/cli.md
+++ b/sections/cli.md
@@ -150,7 +150,7 @@ Some example useful invocations:
    environments.
 
 _new in 2.18.0_: `pre-commit install` will now install hooks from
-[`default_install_hook_types`](#top_level-default_language_version) if
+[`default_install_hook_types`](#top_level-default_install_hook_types) if
 `--hook-type` is not specified on the command line.
 
 ## pre-commit install-hooks [options] #pre-commit-install-hooks


### PR DESCRIPTION
Changed the link to `default_install_hook_types` in the `pre-commit install` section of the docs to point from `#top_level-default_language_version` to `#top_level-default_install_hook_types`.

Fixes #746