### PR TITLE
Add terraform-docs

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -225,3 +225,4 @@
 - https://gitlab.com/adam-moss/pre-commit-trailer
 - https://gitlab.com/adam-moss/pre-commit-ssh-git-signing-key
 - https://github.com/charliermarsh/ruff-pre-commit
+- https://github.com/terraform-docs/terraform-docs


### PR DESCRIPTION
I just found these hooks and want to add them to the list 😸

<!-- if your edit is to something other than all-repos.yaml remove this -->

my new repository:

- [ ] is added to the bottom *or* with existing repos from the same account
- [ ] contains a license
- [ ] is not `language: system` or `language: docker`
- [ ] does not contain "pre-commit" in the name
