### PR TITLE
Adds checkmake repo

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -225,3 +225,4 @@
 - https://gitlab.com/adam-moss/pre-commit-trailer
 - https://gitlab.com/adam-moss/pre-commit-ssh-git-signing-key
 - https://github.com/charliermarsh/ruff-pre-commit
+- https://github.com/mrtazz/checkmake


### PR DESCRIPTION
checkmake got a hook configuration in https://github.com/mrtazz/checkmake/commit/4e37f3a6ea00208b3f5bd04eaa0f075068237f18

<!-- if your edit is to something other than all-repos.yaml remove this -->

my new repository:

- [x] is added to the bottom *or* with existing repos from the same account
- [x] contains a license
- [x] is not `language: system` or `language: docker`
- [x] does not contain "pre-commit" in the name
