### PR TITLE
Change url following repo migration

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -222,6 +222,7 @@
 - https://github.com/omnilib/ufmt
 - https://github.com/daveshanley/vacuum
 - https://github.com/nuztalgia/botstrap
-- https://gitlab.com/adam-moss/pre-commit-trailer
-- https://gitlab.com/adam-moss/pre-commit-ssh-git-signing-key
 - https://github.com/charliermarsh/ruff-pre-commit
+- https://gitlab.com/repo-hooks/pre-commit-community-health
+- https://gitlab.com/repo-hooks/pre-commit-git-signing-key
+- https://gitlab.com/repo-hooks/pre-commit-trailer


### PR DESCRIPTION
GitLab have accepted pre-commit-trailer and pre-commit-git-signing-key into their open source licensing programme.  To take full advantage of this the repositories have been moved from my personal namespace into a group.

The adam-moss versions will be updated to fail and advise the user of the new location in due course.

I've also added a new one, pre-commit-community-health, which is currently in an early alpha state pending.

Signed-off-by: Adam Moss <2951486+adam-moss@users.noreply.github.com>

<!-- if your edit is to something other than all-repos.yaml remove this -->

my new repository:

- [X] is added to the bottom *or* with existing repos from the same account
- [X] contains a license
- [x] is not `language: system` or `language: docker`
- [ ] does not contain "pre-commit" in the name
