### PR TITLE
Use non-broken rev in black formatter hook

### DIFF
--- a/sections/install.md
+++ b/sections/install.md
@@ -64,7 +64,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.10.0
     hooks:
     -   id: black
 ```


### PR DESCRIPTION
As mentioned in https://github.com/pre-commit/pre-commit/issues/2663 :

> Newcomers tend to copy-and-paste from documentation to try things out, if they get an error they'll tend to assume that something went wrong with their installation
>
> I understand not wanting to always keep it pinned to the latest versions, but at least not pinning to a broken rev seems like a reasonable ask
