### PR TITLE
Add `git-lfs-hooks-mirror` to the supported hooks

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -227,3 +227,4 @@
 - https://github.com/charliermarsh/ruff-pre-commit
 - https://github.com/mrtazz/checkmake
 - https://github.com/jshwi/docsig
+- https://github.com/KAUTH/git-lfs-hooks-mirror


### PR DESCRIPTION
These hooks mirror the Git LFS hooks.

This includes four hook types:
- post-checkout
- post-commit
- post-merge
- pre-push

<!-- if your edit is to something other than all-repos.yaml remove this -->

my new repository:

- [x] is added to the bottom *or* with existing repos from the same account
- [x] contains a license
- [x] is not `language: system` or `language: docker`
- [x] does not contain "pre-commit" in the name
