### PR TITLE
Add zeek-format to to list of all hooks

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -228,3 +228,4 @@
 - https://github.com/mrtazz/checkmake
 - https://github.com/jshwi/docsig
 - https://github.com/finsberg/clang-format-docs
+- https://github.com/AmazingPP/zeek-format-precommit


### PR DESCRIPTION
[zeek-format](https://github.com/zeek/zeekscript#zeek-format) is a [Zeek script](https://docs.zeek.org/en/master/scripting/basics.html) formatter.