### PR TITLE
Add rubocop/rubocop to all-repos.yaml

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -228,3 +228,4 @@
 - https://github.com/mrtazz/checkmake
 - https://github.com/jshwi/docsig
 - https://github.com/finsberg/clang-format-docs
+- https://github.com/rubocop/rubocop


### PR DESCRIPTION
<!-- if your edit is to something other than all-repos.yaml remove this -->

my new repository:

- [x] is added to the bottom *or* with existing repos from the same account
- [x] contains a license
- [x] is not `language: system` or `language: docker`
- [x] does not contain "pre-commit" in the name
