### PR TITLE
Added Christopher Pickering's pre-commit-hooks

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -229,3 +229,4 @@
 - https://github.com/jshwi/docsig
 - https://github.com/finsberg/clang-format-docs
 - https://github.com/rubocop/rubocop
+- https://github.com/christopherpickering/pre-commit-hooks


### PR DESCRIPTION
The primary hook converts Poetry's requirements to a requirement.txt file.

<!-- if your edit is to something other than all-repos.yaml remove this -->

my new repository:

- [ ] is added to the bottom *or* with existing repos from the same account
- [ ] contains a license
- [ ] is not `language: system` or `language: docker`
- [ ] does not contain "pre-commit" in the name
