### PR TITLE
Better document Rust's first-class support

### DIFF
--- a/sections/new-hooks.md
+++ b/sections/new-hooks.md
@@ -418,8 +418,8 @@ been tested on linux and macOS and _may_ work under cygwin.
 
 ### rust
 
-Rust hooks are installed using the system installation of
-[Cargo](https://github.com/rust-lang/cargo), Rust's official package manager.
+Rust hooks are installed using [Cargo](https://github.com/rust-lang/cargo),
+Rust's official package manager.
 
 Hook repositories must have a `Cargo.toml` file which produces at least one
 binary ([example](https://github.com/chriskuehl/example-rust-pre-commit-hook)),
@@ -433,7 +433,8 @@ build _your_ hook repo), or the special syntax
 `cli:{package_name}:{package_version}` for a CLI dependency (built separately,
 with binaries made available for use by hooks).
 
-_new in 2.21.0_: rust now supports `language_version`.
+_new in 2.21.0_: pre-commit will bootstrap `rust` if it is not present.
+`language: rust` also now supports `language_version`
 
 __Support:__ It has been tested on linux, Windows, and macOS.
 


### PR DESCRIPTION
Some edits to the rust section to make it clear that Rust is not required on your system since https://github.com/pre-commit/pre-commit/pull/2534 . I copied from the recent golang edit: https://github.com/pre-commit/pre-commit.com/pull/779/files#diff-eb3204ca6c95d85efdd8fad58315793d3e9e7099edec604b8b659677e87d26b5R320-R321