### PR TITLE
Add JohnDevlopment/pre-commit-hooks to the list of repos

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -230,3 +230,4 @@
 - https://github.com/jshwi/docsig
 - https://github.com/finsberg/clang-format-docs
 - https://github.com/rubocop/rubocop
+- https://github.com/JohnDevlopment/pre-commit-hooks


### PR DESCRIPTION
<!-- if your edit is to something other than all-repos.yaml remove this -->

my new repository:

- [X] is added to the bottom *or* with existing repos from the same account
- [X] contains a license
- [X] is not `language: system` or `language: docker`
- [ ] does not contain "pre-commit" in the name
