### PR TITLE
Add hooks for LaTeX linters with valid repo name

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -232,3 +232,4 @@
 - https://github.com/rubocop/rubocop
 - https://gitlab.com/engmark/vcard
 - https://github.com/Data-Liberation-Front/csvlint.rb
+- https://github.com/joclement/latex-linters-hooks


### PR DESCRIPTION
<!-- if your edit is to something other than all-repos.yaml remove this -->

my new repository:

- [x] is added to the bottom *or* with existing repos from the same account
- [x] contains a license
- [x] is not `language: system` or `language: docker`
- [x] does not contain "pre-commit" in the name

Sorry for not having the name correctly in the first place.