### PR TITLE
Add hook to check and strip GPS metadata

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -232,3 +232,4 @@
 - https://github.com/rubocop/rubocop
 - https://gitlab.com/engmark/vcard
 - https://github.com/Data-Liberation-Front/csvlint.rb
+- https://github.com/nuket/Eigendoxx


### PR DESCRIPTION
Detect and remove GPS data from images using pre-commit hook. Usually happens by accident, but it does happen.

my new repository:

- [x] is added to the bottom *or* with existing repos from the same account
- [x] contains a license
- [x] is not `language: system` or `language: docker`
- [x] does not contain "pre-commit" in the name
