### PR TITLE
Add python filename linter repo

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -233,3 +233,4 @@
 - https://github.com/dbt-checkpoint/dbt-checkpoint
 - https://gitlab.com/engmark/vcard
 - https://github.com/Data-Liberation-Front/csvlint.rb
+- https://github.com/ClementPinard/python_filename_linter


### PR DESCRIPTION
Hi, thanks for this nice tool !

Added a small hook I developed because I was tired to see my colleagues using PascalCase for python filenames instead of snake_case.

my new repository:

- [ X ] is added to the bottom *or* with existing repos from the same account
- [ X ] contains a license
- [ X ] is not `language: system`, `language: script`, or `language: docker`
- [ X ] does not contain "pre-commit" in the name
