### PR TITLE
Add gitlab.com/brettops/pre-commit-hooks/verilog

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -234,3 +234,4 @@
 - https://github.com/dbt-checkpoint/dbt-checkpoint
 - https://gitlab.com/engmark/vcard
 - https://github.com/Data-Liberation-Front/csvlint.rb
+- https://gitlab.com/brettops/pre-commit-hooks/verilog


### PR DESCRIPTION
<!-- if your edit is to something other than all-repos.yaml remove this -->

my new repository:

- [x] is added to the bottom *or* with existing repos from the same account
- [x] contains a license
- [x] is not `language: system`, `language: script`, or `language: docker` (it is `docker_image`)
- [ ] does not contain "pre-commit" in the name (the parent group is named `brettops/pre-commit-hooks`)
