### PR TITLE
Add django-ensure-makemessages to all-repos

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -234,4 +234,4 @@
 - https://github.com/dbt-checkpoint/dbt-checkpoint
 - https://gitlab.com/engmark/vcard
 - https://github.com/Data-Liberation-Front/csvlint.rb
-- https://gitlab.com/nils-van-zuijlen/pre-commit-django-makemessages
+- https://gitlab.com/nils-van-zuijlen/django-ensure-makemessages


### PR DESCRIPTION
my new repository:

- [x] is added to the bottom *or* with existing repos from the same account
- [x] contains a license
- [x] is not `language: system`, `language: script`, or `language: docker`
- [x] does not contain "pre-commit" in the name
