### PR TITLE
Add `real-yfprojects/check-pre-commit-config` hook

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -234,3 +234,4 @@
 - https://github.com/dbt-checkpoint/dbt-checkpoint
 - https://gitlab.com/engmark/vcard
 - https://github.com/Data-Liberation-Front/csvlint.rb
+- https://github.com/real-yfprojects/check-pre-commit-config


### PR DESCRIPTION
The [repo](https://github.com/real-yfprojects/check-pre-commit-config) holds my pre-commit hooks running on `.pre-commit-config.yaml` and currently contains a single hook called `check-frozen`. This hook enforces rules regarding the use of frozen revisions and regarding annotating them with a `frozen: xxx` comment. Some rules can be fixed automatically by this hook.

<!-- if your edit is to something other than all-repos.yaml remove this -->

my new repository:

- [x] is added to the bottom *or* with existing repos from the same account
- [x] contains a license
- [x] is not `language: system`, `language: script`, `language: docker`, or `language: docker_image`
- [ ] does not contain "pre-commit" in the name
