### PR TITLE
Remove adamchainz/pre-commit-dprint

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -201,7 +201,6 @@
 - https://github.com/rapidsai/frigate
 - https://github.com/norwoodj/helm-docs
 - https://github.com/sqlfluff/sqlfluff
-- https://github.com/adamchainz/pre-commit-dprint
 - https://github.com/adamchainz/blacken-docs
 - https://github.com/adamchainz/django-upgrade
 - https://github.com/scop/pre-commit-shfmt


### PR DESCRIPTION
Removing this repository as it is now archived due to not dprint not working correctly under pre-commit: https://github.com/adamchainz/pre-commit-dprint