### PR TITLE
add `nim65s/pre-commit-sort` hook

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -233,3 +233,4 @@
 - https://github.com/dbt-checkpoint/dbt-checkpoint
 - https://gitlab.com/engmark/vcard
 - https://github.com/Data-Liberation-Front/csvlint.rb
+- https://github.com/nim65s/pre-commit-sort


### PR DESCRIPTION
Hi,

Thanks for this project !

I wrote a simple rust program which validates `.pre-commit-config.yaml` & `.pre-commit-hooks.yaml` files, and then sort and dedup them. It helps me to manage those files across different projects/repos by allowing good diffs.

As this is working exclusively on pre-commit related files, I humbly request a derogation on the fourth requirement. But obviously, if this is not suitable, I can still rename this new project of mine, which is still in beta phase: I just think its goal will be less explicit.



my new repository:

- [x] is added to the bottom *or* with existing repos from the same account
- [x] contains a license
- [x] is not `language: system`, `language: script`, `language: docker`, or `language: docker_image`
- [ ] does not contain "pre-commit" in the name
