### PR TITLE
Adding `bump-helm-chart-version` to supported hooks list

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -234,3 +234,4 @@
 - https://gitlab.com/engmark/vcard
 - https://github.com/Data-Liberation-Front/csvlint.rb
 - https://github.com/christopher-hacker/enforce-notebook-run-order
+- https://github.com/devqik/bump-helm-chart-version


### PR DESCRIPTION
`bump-helm-chart-version` is a pre-commit hook written in Python 3. It is used to automatically bump the Helm chart patch version if the chart has changes in the /templates folder or changes in helper functions files.

my new repository:

- [x] is added to the bottom *or* with existing repos from the same account
- [x] contains a license
- [x] is not `language: system`, `language: script`, `language: docker`, or `language: docker_image`
- [x] does not contain "pre-commit" in the name
