### PR TITLE
Add python poetry repository to list of supported hooks

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -225,3 +225,4 @@
 - https://gitlab.com/adam-moss/pre-commit-trailer
 - https://gitlab.com/adam-moss/pre-commit-ssh-git-signing-key
 - https://github.com/charliermarsh/ruff-pre-commit
+- https://github.com/python-poetry/poetry


### PR DESCRIPTION
https://python-poetry.org/docs/master/pre-commit-hooks/

<!-- if your edit is to something other than all-repos.yaml remove this -->

my new repository:

- [X] is added to the bottom *or* with existing repos from the same account
- [X] contains a license
- [X] is not `language: system`, `language: script`, `language: docker`, or `language: docker_image`
- [X] does not contain "pre-commit" in the name
