### PR TITLE
sections/advanced.md: Avoid warning on old action

### DIFF
--- a/sections/advanced.md
+++ b/sections/advanced.md
@@ -706,7 +706,7 @@ immutable caches:
 ```yaml
     - name: set PY
       run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-    - uses: actions/cache@v1
+    - uses: actions/cache@v3
       with:
         path: ~/.cache/pre-commit
         key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}


### PR DESCRIPTION
Old actions which use node 12 currently spew a warning, see [1].

Let's use the latest version in the documentation here to help future users.

[1]: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
