### PR TITLE
post_commit missing from list "Supported git hooks"

### DIFF
--- a/sections/advanced.md
+++ b/sections/advanced.md
@@ -82,6 +82,7 @@ pre-commit installed at .git/hooks/commit-msg
 
 - [commit-msg](#commit-msg)
 - [post-checkout](#post-checkout)
+- [post-commit](#post-commit)
 - [post-merge](#post-merge)
 - [post-rewrite](#post-rewrite)
 - [pre-commit](#pre-commit)


### PR DESCRIPTION
*post_commit* was missing from the list "Supported git hooks": https://pre-commit.com/#supported-git-hooks