### PR TITLE
Update deprecated `yapf` to the official source in `all-repos.yaml`

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -10,7 +10,6 @@
 - https://github.com/pre-commit/mirrors-prettier
 - https://github.com/pre-commit/mirrors-puppet-lint
 - https://github.com/pre-commit/mirrors-scss-lint
-- https://github.com/pre-commit/mirrors-yapf
 - https://github.com/pre-commit/pygrep-hooks
 - https://github.com/pre-commit/sync-pre-commit-deps
 - https://github.com/FalconSocial/pre-commit-mirrors-pep257
@@ -167,6 +166,7 @@
 - https://github.com/hadolint/hadolint
 - https://github.com/google/go-jsonnet
 - https://github.com/google/yamlfmt
+- https://github.com/google/yapf
 - https://github.com/guid-empty/flutter-dependency-validation-pre-commit
 - https://github.com/cpplint/cpplint
 - https://github.com/MarcoGorelli/absolufy-imports


### PR DESCRIPTION
Update yapf

<!-- if your edit is to something other than all-repos.yaml remove this -->

<!-- if you cannot satisfy these requirements do not open a PR -->

my new repository:

- [x] is added to the bottom *or* with existing repos from the same account
- [x] contains a license
- [x] is not `language: system`, `language: script`, `language: docker`, or `language: docker_image`
- [x] does not contain "pre-commit" in the name
