### PR TITLE
Docs: add note about pre-push hooks not being triggered on ref deletions

### DIFF
--- a/sections/advanced.md
+++ b/sections/advanced.md
@@ -182,6 +182,8 @@ Note that you need to be using at least git 2.24 for this hook.
 
 `pre-push` is triggered on `git push`.
 
+note: `pre-push` hooks are not triggered for ref deletions.
+
 environment variables:
 - `PRE_COMMIT_FROM_REF`: the revision that is being pushed to.
 - `PRE_COMMIT_TO_REF`: the local revision that is being pushed to the remote.


### PR DESCRIPTION
Documents behavior described in https://github.com/pre-commit/pre-commit/issues/3050