### PR TITLE
add Conventional Precommit Linter hook

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -240,3 +240,4 @@
 - https://github.com/andrewring/github-distributed-owners
 - https://github.com/Mermeid-Designs/pydantic-hooks
 - https://github.com/igrr/astyle_py
+- https://github.com/espressif/conventional-precommit-linter


### PR DESCRIPTION
<!-- if your edit is to something other than all-repos.yaml remove this -->

<!-- if you cannot satisfy these requirements do not open a PR -->

[my new repository](https://github.com/espressif/conventional-precommit-linter):

- [x] is added to the bottom *or* with existing repos from the same account
- [x] contains a license
- [x] is not `language: system`, `language: script`, `language: docker`, or `language: docker_image`
- [x] does not contain "pre-commit" in the name
