### PR TITLE
require short names by default

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -27,14 +27,14 @@
 - https://github.com/digitalpulp/pre-commit-php
 - https://github.com/elidupuis/mirrors-jscs
 - https://github.com/elidupuis/mirrors-sass-lint
-- https://github.com/jumanjihouse/pre-commit-hooks
+# - https://github.com/jumanjihouse/pre-commit-hooks
 - https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
 - https://github.com/Lucas-C/pre-commit-hooks
 - https://github.com/Lucas-C/pre-commit-hooks-go
-- https://github.com/Lucas-C/pre-commit-hooks-java
+# - https://github.com/Lucas-C/pre-commit-hooks-java
 - https://github.com/Lucas-C/pre-commit-hooks-lxml
-- https://github.com/Lucas-C/pre-commit-hooks-markup
-- https://github.com/Lucas-C/pre-commit-hooks-nodejs
+# - https://github.com/Lucas-C/pre-commit-hooks-markup
+# - https://github.com/Lucas-C/pre-commit-hooks-nodejs
 - https://github.com/Lucas-C/pre-commit-hooks-safety
 - https://github.com/chriskuehl/puppet-pre-commit-hooks
 - https://github.com/golangci/golangci-lint
@@ -154,10 +154,10 @@
 - https://gitlab.com/pablodiehl/pre-commit-lua-formatter
 - https://github.com/frnmst/md-toc
 - https://github.com/mgedmin/check-manifest
-- https://github.com/ecugol/pre-commit-hooks-django
+# - https://github.com/ecugol/pre-commit-hooks-django
 - https://github.com/PrincetonUniversity/blocklint
 - https://github.com/python-jsonschema/check-jsonschema
-- https://github.com/sirosen/texthooks
+# - https://github.com/sirosen/texthooks
 - https://github.com/snok/pep585-upgrade
 - https://github.com/jendrikseipp/vulture
 - https://github.com/mwouts/jupytext
@@ -185,8 +185,8 @@
 - https://github.com/chrismgrayftsinc/jsonnetfmt
 - https://github.com/zricethezav/gitleaks
 - https://github.com/hugoh/pre-commit-fish
-- https://github.com/nbyl/pre-commit-license-checks
-- https://github.com/jonasbb/pre-commit-latex-hooks
+# - https://github.com/nbyl/pre-commit-license-checks
+# - https://github.com/jonasbb/pre-commit-latex-hooks
 - https://github.com/dfm/black_nbconvert
 - https://github.com/crate-ci/typos
 - https://github.com/snakemake/snakefmt
@@ -231,7 +231,7 @@
 - https://github.com/jshwi/docsig
 - https://github.com/finsberg/clang-format-docs
 - https://github.com/rubocop/rubocop
-- https://github.com/dbt-checkpoint/dbt-checkpoint
+# - https://github.com/dbt-checkpoint/dbt-checkpoint
 - https://gitlab.com/engmark/vcard
 - https://github.com/Data-Liberation-Front/csvlint.rb
 - https://github.com/christopher-hacker/enforce-notebook-run-order

--- a/make_all_hooks.py
+++ b/make_all_hooks.py
@@ -33,6 +33,10 @@ def get_manifest(repo_path: str) -> tuple[bool, str, list[dict[str, Any]]]:
             if hook['fail_fast']:
                 print(f'{repo_path} ({hook["id"]}) sets `fail_fast: true`')
                 return False, repo_path, []
+            # hook names should be short and not cause wrapping by default
+            if len(hook['name']) > 50:
+                print(f'{repo_path} ({hook["id"]}) has too long `name` (>50)')
+                return False, repo_path, []
 
         with open(manifest_path) as f:
             return True, repo_path, fast_load(f)


### PR DESCRIPTION
this adds an additional check to the hooks page which requires names not cause wrapping by default

if you've been linked to this PR -- it's because your repository was disabled -- please pick a shorter `name` and re-enable your repository.  the limit for names to be included on `hooks.html` is 50 characters (anything more than this will stretch the default pre-commit output)