### PR TITLE
Reenable 'sirosen/texthooks' in all-repos.yaml

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -157,7 +157,7 @@
 # - https://github.com/ecugol/pre-commit-hooks-django
 - https://github.com/PrincetonUniversity/blocklint
 - https://github.com/python-jsonschema/check-jsonschema
-# - https://github.com/sirosen/texthooks
+- https://github.com/sirosen/texthooks
 - https://github.com/snok/pep585-upgrade
 - https://github.com/jendrikseipp/vulture
 - https://github.com/mwouts/jupytext


### PR DESCRIPTION
This re-enables `github.com/sirosen/texthooks`, now that I've taken the offending hook name down to < 50 chars and added a lint to make sure they don't get too long in the future.