### PR TITLE
Add gitlab-ci-tools and codeowners-generator

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -242,3 +242,5 @@
 - https://github.com/igrr/astyle_py
 - https://gitlab.com/codementors/pre-commit/add-issue-number-to-conventional-commit
 - https://github.com/numpy/numpydoc
+- https://github.com/c0m1c5an5/gitlab-ci-tools
+- https://github.com/c0m1c5an5/codeowners-generator


### PR DESCRIPTION
Add gitlab-ci-tools repo that provides a shellcheck, linter and formatter tools for gitlab ci pipeline files.
Add codeowners-generator repo that provides a hook that keeps CODEOWNERS up to date. 

<!-- if your edit is to something other than all-repos.yaml remove this -->

<!-- if you cannot satisfy these requirements do not open a PR -->

my new repository:

- [X] is added to the bottom *or* with existing repos from the same account
- [X] contains a license
- [X] is not `language: system`, `language: script`, `language: docker`, or `language: docker_image`
- [X] does not contain "pre-commit" in the name
