### PR TITLE
allow deprecated hooks to exceed character limit

### DIFF
--- a/make_all_hooks.py
+++ b/make_all_hooks.py
@@ -34,7 +34,10 @@ def get_manifest(repo_path: str) -> tuple[bool, str, list[dict[str, Any]]]:
                 print(f'{repo_path} ({hook["id"]}) sets `fail_fast: true`')
                 return False, repo_path, []
             # hook names should be short and not cause wrapping by default
-            if len(hook['name']) > 50:
+            if (
+                    len(hook['name']) > 50 and
+                    'deprecated' not in hook['name'].lower()
+            ):
                 print(f'{repo_path} ({hook["id"]}) has too long `name` (>50)')
                 return False, repo_path, []
 


### PR DESCRIPTION
the particular one was https://github.com/antonbabenko/pre-commit-terraform/blob/03705ce283b735a4b8ae097e7486ea9257b4fd97/.pre-commit-hooks.yaml#L89