### PR TITLE
docs: updates ruff pre-commit

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -226,7 +226,7 @@
 - https://github.com/nuztalgia/botstrap
 - https://gitlab.com/adam-moss/pre-commit-trailer
 - https://gitlab.com/adam-moss/pre-commit-ssh-git-signing-key
-- https://github.com/charliermarsh/ruff-pre-commit
+- https://github.com/astral-sh/ruff-pre-commit
 - https://github.com/mrtazz/checkmake
 - https://github.com/jshwi/docsig
 - https://github.com/finsberg/clang-format-docs


### PR DESCRIPTION
<!-- if your edit is to something other than all-repos.yaml remove this -->

<!-- if you cannot satisfy these requirements do not open a PR -->

Updates charliermarsh/ruff-pre-commit to [astral-sh/ruff-pre-commit](https://github.com/astral-sh/ruff-pre-commit):

- [ ] is added to the bottom *or* with existing repos from the same account
- [ ] contains a license
- [ ] is not `language: system`, `language: script`, `language: docker`, or `language: docker_image`
- [ ] does not contain "pre-commit" in the name
