### PR TITLE
Describe how `identity` hook can be used to print messages

### DIFF
--- a/sections/advanced.md
+++ b/sections/advanced.md
@@ -357,7 +357,8 @@ The currently available `meta` hooks:
 =r=
     =c= [`identity`](_#meta-identity)
     =c= a simple hook which prints all arguments passed to it, useful for
-        debugging.
+        debugging or printing a help message (if `pass_filenames` is set to
+        `false`).
 ```
 
 ## automatically enabling pre-commit on repositories

--- a/sections/advanced.md
+++ b/sections/advanced.md
@@ -357,8 +357,18 @@ The currently available `meta` hooks:
 =r=
     =c= [`identity`](_#meta-identity)
     =c= a simple hook which prints all arguments passed to it, useful for
-        debugging or printing a help message (if `pass_filenames` is set to
-        `false`).
+        debugging.
+```
+
+The `identity` hook can be used to print a message when `pre-commit` is run:
+
+```yaml
+-   repo: meta
+    hooks:
+    -   id: identity
+        name: Print troubleshooting information
+        args: ['For help with troubleshooting, please see our documentation.']
+        pass_filenames: false
 ```
 
 ## automatically enabling pre-commit on repositories


### PR DESCRIPTION
This PR mentions that the `identity` hook can be used to print a message when `pre-commit` is run.

For a bit of context, a while back I was looking for a way to print out a message with a link to our troubleshooting guide when a new contributor encountered a `pre-commit` failure.  I couldn't find anything in the documentation, so I ended up finding https://github.com/pre-commit/pre-commit/issues/1565.  It took a few iterations before settling on the very helpful suggestions to use the `identity` hook.  I wanted to add this to the documentation since it would have probably saved me ∼2–3 hours of time and prevented a lot of frustration.  

Thank you!


