### PR TITLE
Extend golang docs: additional dependencies and tooling semantics

### DIFF
--- a/sections/new-hooks.md
+++ b/sections/new-hooks.md
@@ -314,6 +314,9 @@ The hook repository must contain go source code.  It will be installed via
 and the [`entry`](#hooks-entry) should match an executable which will get installed into the
 `GOPATH`'s `bin` directory.
 
+This language supports `additional_dependencies` and will pass any of the values directly to `go
+install`. It can be used as a `repo: local` hook.
+
 _changed in 2.17.0_: previously `go get ./...` was used
 
 _new in 3.0.0_: pre-commit will bootstrap `go` if it is not present. `language: golang`


### PR DESCRIPTION
Minor improvements to the docs on `golang` hooks:

- In `golang` hooks, `additional_dependencies` can be used. According to the existing docs on other language hooks, I have added a note on that. See also issue #797.
- The second paragraph is a summary of my findings from setting up `golang` hooks. It might be worth adding this for the benefit of others?