### PR TITLE
Add https://github.com/PaulinaPacyna/type-hint-checker to the list

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -246,3 +246,4 @@
 - https://github.com/hakancelikdev/unexport
 - https://github.com/KindDragon/gn-build-py
 - https://github.com/stefmolin/exif-stripper
+- https://github.com/PaulinaPacyna/type-hint-checker


### PR DESCRIPTION
Hi, I am working on a new pre-commit hook that warns the user, if he/she forgot to add type hints to the function signature.
I would appreciate if it could be displayed on the list.
my new repository:

- [x] is added to the bottom *or* with existing repos from the same account
- [x] contains a license
- [x] is not `language: system`, `language: script`, `language: docker`, or `language: docker_image`
- [x] does not contain "pre-commit" in the name
