### PR TITLE
Add actionlint to list of pre-commit hooks

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -246,3 +246,4 @@
 - https://github.com/KindDragon/gn-build-py
 - https://github.com/stefmolin/exif-stripper
 - https://github.com/hhatto/autopep8
+- https://github.com/rhysd/actionlint


### PR DESCRIPTION
Alternative to actionlint-py that makes use of `golang` directly. In contrast to when this was requested to be added in https://github.com/pre-commit/pre-commit.com/pull/702, the config contains now a `golang` entry.

my new repository:

- [x] is added to the bottom *or* with existing repos from the same account
- [x] contains a license
- [x] is not `language: system`, `language: script`, `language: system`, or `language: docker_image`
- [x] does not contain "pre-commit" in the name

The repo contains `language: system` and `language: system`, but since it contains `language: golang` as well, I ticked that box.