### PR TITLE
Added clean-dotenv to all-repos.yaml

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -246,3 +246,4 @@
 - https://github.com/stefmolin/exif-stripper
 - https://github.com/hhatto/autopep8
 - https://github.com/rhysd/actionlint
+- https://github.com/hija/clean-dotenv


### PR DESCRIPTION
Hi there,

I created a pre-commit hook which creates a .env.example file (derived from the .env file).

My new repository:

- [x] is added to the bottom *or* with existing repos from the same account
- [x] contains a license
- [x] is not `language: system`, `language: script`, `language: docker`, or `language: docker_image`
- [x] does not contain "pre-commit" in the name
