### PR TITLE
remove archived hook repo

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -29,7 +29,6 @@
 # - https://github.com/jumanjihouse/pre-commit-hooks
 - https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
 - https://github.com/Lucas-C/pre-commit-hooks
-- https://github.com/Lucas-C/pre-commit-hooks-go
 # - https://github.com/Lucas-C/pre-commit-hooks-java
 - https://github.com/Lucas-C/pre-commit-hooks-lxml
 # - https://github.com/Lucas-C/pre-commit-hooks-markup


### PR DESCRIPTION
https://github.com/Lucas-C/pre-commit-hooks-go/commit/223d5d97082ae7c10c1a5b00afdeb131e03e1991

Official replacement is already included in list.

<!-- if your edit is to something other than all-repos.yaml remove this -->

<!-- if you cannot satisfy these requirements do not open a PR -->

my new repository:

- [ ] is added to the bottom *or* with existing repos from the same account
- [ ] contains a license
- [ ] is not `language: system`, `language: script`, `language: docker`, or `language: docker_image`
- [ ] does not contain "pre-commit" in the name
- [X] above does not apply since I am just removing superseeded repo
