### PR TITLE
Add pixi as one of the install steps

### DIFF
--- a/sections/install.md
+++ b/sections/install.md
@@ -34,6 +34,12 @@ Using [conda](https://conda.io) (via [conda-forge](https://conda-forge.org)):
 conda install -c conda-forge pre-commit
 ```
 
+Using [pixi](https://pixi.sh/latest/#installation):
+
+```bash
+pixi global install pre-commit
+```
+
 ## Quick start
 
 ### 1. Install pre-commit


### PR DESCRIPTION
I would like to suggest  [pixi](https://pixi.sh/latest/)  ( which brings cargo/npm/yarn like package management experience for conda) as one of the possible installation way of pre-commit.
