### PR TITLE
Add AlexanderDokuchaev/md-dead-link-check to all-repos.yaml

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -247,3 +247,4 @@
 - https://github.com/hhatto/autopep8
 - https://github.com/rhysd/actionlint
 - https://github.com/hija/clean-dotenv
+- https://github.com/AlexanderDokuchaev/md-dead-link-check


### PR DESCRIPTION
Add [AlexanderDokuchaev/md-dead-link-check](https://github.com/AlexanderDokuchaev/md-dead-link-check), hook to check broken links in markdown files.

my new repository:

- [x] is added to the bottom *or* with existing repos from the same account
- [x] contains a license
- [x] is not `language: system`, `language: script`, `language: docker`, or `language: docker_image`
- [x] does not contain "pre-commit" in the name
