### PR TITLE
Add blocking-comment to all-repos.yaml

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -248,4 +248,3 @@
 - https://github.com/rhysd/actionlint
 - https://github.com/hija/clean-dotenv
 - https://github.com/dbhagen/blocking-comment
-

--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -247,3 +247,4 @@
 - https://github.com/hhatto/autopep8
 - https://github.com/rhysd/actionlint
 - https://github.com/hija/clean-dotenv
+- https://github.com/dbhagen/blocking-comment

--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -248,3 +248,4 @@
 - https://github.com/rhysd/actionlint
 - https://github.com/hija/clean-dotenv
 - https://github.com/dbhagen/blocking-comment
+


### PR DESCRIPTION
Add `blocking-comment`: https://github.com/dbhagen/blocking-comment

my new repository:

- [X] is added to the bottom *or* with existing repos from the same account
- [X] contains a license
- [X] is not `language: system`, `language: script`, `language: docker`, or `language: docker_image`
- [X] does not contain "pre-commit" in the name
