### PR TITLE
docs: add commitlint mirror

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -247,3 +247,4 @@
 - https://github.com/hhatto/autopep8
 - https://github.com/rhysd/actionlint
 - https://github.com/hija/clean-dotenv
+- https://github.com/aentwist/pre-commit-mirrors-commitlint


### PR DESCRIPTION
Offer alternative commitlint hooks that:

1. have tags matching the version of commitlint by using pre-commit-mirror-maker
2. include a robust CI hook

<!-- if your edit is to something other than all-repos.yaml remove this -->

<!-- if you cannot satisfy these requirements do not open a PR -->

my new repository:

- [x] is added to the bottom *or* with existing repos from the same account - yes
- [x] contains a license - MIT
- [x] is not `language: system`, `language: script`, `language: docker`, or `language: docker_image` - `node`
- [ ] does not contain "pre-commit" in the name

I apologize for opening this despite not meeting requirement 4 above. I see repos that also do not meet it (grandfathered?), and I do not think my repo name would make sense without including "pre-commit" for context as that is its entire purpose. If you find this unsatisfactory, I understand.
