### PR TITLE
Add Artalus/mypy-hook-venv to all-repos.yaml

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -247,3 +247,4 @@
 - https://github.com/hhatto/autopep8
 - https://github.com/rhysd/actionlint
 - https://github.com/hija/clean-dotenv
+- https://github.com/Artalus/mypy-hook-venv


### PR DESCRIPTION
Hi! This isn't so much a request to include a new hook to The List, as it is a request for your input on `mypy-mirror` limitations regarding custom imports 🙃 

I am somewhat unsatisfied with `mypy-mirror` nudging you to duplicate dependencies in `.pre-commit-config.yaml`, and with it potentially using a different `mypy` version than required in the typechecked project. So I sought for a solution that would be both IDE- and virtualenv-friendly - yet portable between different machines/developers. I have been successfully using this hook for about a month now, both locally and in CI. My repos all follow the same approach where `mypy` is installed in the same `virtualenv` as the package it checks and its dependencies - so this might be a limitation, if other seasoned Python devs tend to use mypy differently.

I wonder if, despite requiring additional configuration on the user's side, this would be of help to other users of Pre-Commit, and maybe even to Pre-Commit development itself.

my new repository:

- [x] is added to the bottom *or* with existing repos from the same account
- [x] contains a license
- [x] is not `language: system`, `language: script`, `language: docker`, or `language: docker_image`
- [x] does not contain "pre-commit" in the name
