### PR TITLE
Re-enabling dbt-checkpoint now that names are <=50 chars

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -229,7 +229,7 @@
 - https://github.com/jshwi/docsig
 - https://github.com/finsberg/clang-format-docs
 - https://github.com/rubocop/rubocop
-# - https://github.com/dbt-checkpoint/dbt-checkpoint
+- https://github.com/dbt-checkpoint/dbt-checkpoint
 - https://gitlab.com/engmark/vcard
 - https://github.com/Data-Liberation-Front/csvlint.rb
 - https://github.com/christopher-hacker/enforce-notebook-run-order


### PR DESCRIPTION
<!-- if your edit is to something other than all-repos.yaml remove this -->

<!-- if you cannot satisfy these requirements do not open a PR -->

my new repository:

- [ ] is added to the bottom *or* with existing repos from the same account
- [x] contains a license
- [x] is not `language: system`, `language: script`, `language: docker`, or `language: docker_image`
- [x] does not contain "pre-commit" in the name


Addresses [#164](https://github.com/dbt-checkpoint/dbt-checkpoint/issues/164) in `dbt-checkpoint`. Previously `dbt-checkpoint` contained hooks with names > 50 characters, [#209](https://github.com/dbt-checkpoint/dbt-checkpoint/pull/209) fixed this.