### PR TITLE
Add goreadme to all-repos.yaml

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -247,3 +247,4 @@
 - https://github.com/hhatto/autopep8
 - https://github.com/rhysd/actionlint
 - https://github.com/hija/clean-dotenv
+- https://github.com/posener/goreadme


### PR DESCRIPTION
[goreadme](https://github.com/posener/goreadme) generates readme file from Go doc. I just made a [PR](https://github.com/posener/goreadme/pull/133) to add pre-commit support to it.

Here is the sample `.pre-commit-config.yaml` I added as instructions in goreadme's README:
```yaml
repos:
  - repo: https://github.com/posener/goreadme
    rev: v1.4.2 # Use the latest ref
    hooks:
      - id: goreadme
        entry: env README_FILE=README.md goreadme
        args: ['-badge-goreadme=true', '-badge-godoc=true']
```

I had to use `entry: env README_FILE=` because the tool doesn't have a flag for this and [won't have it](https://github.com/posener/goreadme/pull/121#issuecomment-1073172377).

In the `.pre-commit-hooks.yaml`, I used `pass_filenames: false` because goreadme doesn't rely on staged filenames, it reads the repo for *.go files.

my new repository:

- [x] is added to the bottom *or* with existing repos from the same account
- [x] contains a license
- [x] is not `language: system`, `language: script`, `language: docker`, or `language: docker_image`
- [x] does not contain "pre-commit" in the name