### PR TITLE
Add go-arch-lint to all-repos.yaml

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -247,3 +247,4 @@
 - https://github.com/hhatto/autopep8
 - https://github.com/rhysd/actionlint
 - https://github.com/hija/clean-dotenv
+- https://github.com/fe3dback/go-arch-lint


### PR DESCRIPTION
[go-arch-lint](https://github.com/fe3dback/go-arch-lint) checks for architecture of a Go repo and makes sure it comply with your desired configuration.  
I just made a [PR](https://github.com/fe3dback/go-arch-lint/pull/54) to add pre-commit support to it.

Here is the sample `.pre-commit-config.yaml` I added as instructions in go-arch-lint's README:
```yaml
repos:
  - repo: https://github.com/fe3dback/go-arch-lint
    rev: master # Use latest tag
    hooks:
      - id: go-arch-lint-check
      - id: go-arch-lint-graph # optional
        args: ['--include-vendors=true', '--out=go-arch-lint-graph.svg']
```

In the `.pre-commit-hooks.yaml`, I used `pass_filenames: false` because go-arch-lint doesn't rely on staged filenames, it reads the repo for *.go files and the .go-arch-lint.yml file.

my new repository:

- [x] is added to the bottom *or* with existing repos from the same account
- [x] contains a license
- [x] is not `language: system`, `language: script`, `language: docker`, or `language: docker_image`
- [x] does not contain "pre-commit" in the name