### PR TITLE
Add SQLFluff hook wrapper for linting SQL embedded in python strings

### DIFF
--- a/all-repos.yaml
+++ b/all-repos.yaml
@@ -247,3 +247,4 @@
 - https://github.com/hhatto/autopep8
 - https://github.com/rhysd/actionlint
 - https://github.com/hija/clean-dotenv
+- https://github.com/RobertLD/sql_str_lint


### PR DESCRIPTION
<!-- if your edit is to something other than all-repos.yaml remove this -->

<!-- if you cannot satisfy these requirements do not open a PR -->

my new repository:

- [x] is added to the bottom *or* with existing repos from the same account
- [x] contains a license
- [x] is not `language: system`, `language: script`, `language: docker`, or `language: docker_image`
- [x] does not contain "pre-commit" in the name



This hook is similar to the base SQLFluff hook, but utilizes the python AST to lint/fix SQL embedded within string objects in python.
