### PR TITLE
Add pre-commit-shfmt to featured hooks

### DIFF
--- a/sections/hooks.md
+++ b/sections/hooks.md
@@ -45,9 +45,11 @@ for python projects:
 [adamchainz/django-upgrade]: https://github.com/adamchainz/django-upgrade
 
 for shell scripts:
+- [scop/pre-commit-shfmt]: runs shfmt to format shell scripts
 - [shellcheck-py/shellcheck-py]: runs shellcheck on your scripts
 - [openstack/bashate]: code style enforcement for bash programs
 
+[scop/pre-commit-shfmt]: https://github.com/scop/pre-commit-shfmt
 [shellcheck-py/shellcheck-py]: https://github.com/shellcheck-py/shellcheck-py
 [openstack/bashate]: https://github.com/openstack/bashate
 


### PR DESCRIPTION
The tool itself (``shfmt``) is part of https://github.com/mvdan/sh with over 7 thousand stars on GitHub. Their main README recommends https://github.com/scop/pre-commit-shfmt for pre-commit integration (although that repository itself only has 45 stars on GitHub).

See also #587 which added this to ``all-repos.yaml``
