### PR TITLE
update docs for pre-commit 4.0

### DIFF
--- a/sections/advanced.md
+++ b/sections/advanced.md
@@ -101,8 +101,6 @@ aborted if there is a nonzero exit code.
 
 ### post-checkout
 
-_new in 2.2.0_
-
 [git post-checkout docs](https://git-scm.com/docs/githooks#_post_checkout)
 
 post-checkout hooks run *after* a `checkout` has occurred and can be used to
@@ -118,8 +116,6 @@ environment variables:
 
 ### post-commit
 
-_new in 2.4.0_
-
 [git post-commit docs](https://git-scm.com/docs/githooks#_post_commit)
 
 `post-commit` runs after the commit has already succeeded so it cannot be used
@@ -129,8 +125,6 @@ to prevent the commit from happening.
 `always_run: true` or they will always be skipped.
 
 ### post-merge
-
-_new in 2.11.0_
 
 [git post-merge docs](https://git-scm.com/docs/githooks#_post_merge)
 
@@ -143,8 +137,6 @@ environment variables:
 - `PRE_COMMIT_IS_SQUASH_MERGE`: the first argument to the `post-merge` git hook.
 
 ### post-rewrite
-
-_new in 2.15.0_
 
 [git post-rewrite docs](https://git-scm.com/docs/githooks#_post_rewrite)
 
@@ -463,7 +455,7 @@ If a file extension you use is not supported, please
 `types`, `types_or`, and `files` are evaluated together with `AND` when
 filtering.  Tags within `types` are also evaluated using `AND`.
 
-_new in 2.9.0_: Tags within `types_or` are evaluated using `OR`.
+Tags within `types_or` are evaluated using `OR`.
 
 For example:
 
@@ -555,7 +547,7 @@ Valid values for specific languages are listed below:
       windows.
 - node: See [nodeenv](https://github.com/ekalinin/nodeenv#advanced).
 - ruby: See [ruby-build](https://github.com/sstephenson/ruby-build/tree/master/share/ruby-build).
-- _new in 2.21.0_ rust: `language_version` is passed to `rustup`
+- rust: `language_version` is passed to `rustup`
 - _new in 3.0.0_ golang: use the versions on [go.dev/dl](https://go.dev/dl/) such as `1.19.5`
 
 you can set [`default_language_version`](#top_level-default_language_version)

--- a/sections/cli.md
+++ b/sections/cli.md
@@ -6,7 +6,7 @@ All pre-commit commands take the following options:
 - `-c CONFIG`, `--config CONFIG`: path to alternate config file
 - `-h`, `--help`: show help and available options.
 
-_new in 2.8.0_: `pre-commit` now exits with more specific codes:
+`pre-commit` exits with specific codes:
 - `1`: a detected / expected error
 - `3`: an unexpected error
 - `130`: the process was interrupted by `^C`
@@ -68,8 +68,7 @@ $ grep rev: .pre-commit-config.yaml
     rev: 34a269fd7650d264e4de7603157c10d0a9bb8211  # frozen: v1.25.2
 ```
 
-_new in 2.18.0_: pre-commit will preferentially pick tags containing a `.` if
-there are ties.
+pre-commit will preferentially pick tags containing a `.` if there are ties.
 
 ## pre-commit clean [options] #pre-commit-clean
 
@@ -143,7 +142,7 @@ Some example useful invocations:
    existing git hook scripts with pre-commit, and also installs hook
    environments.
 
-_new in 2.18.0_: `pre-commit install` will now install hooks from
+`pre-commit install` will install hooks from
 [`default_install_hook_types`](#top_level-default_install_hook_types) if
 `--hook-type` is not specified on the command line.
 
@@ -178,8 +177,6 @@ Options:
 - `--files [FILES [FILES ...]]`: specific filenames to run hooks on.
 - `--from-ref FROM_REF` + `--to-ref TO_REF`: run against the files changed
   between `FROM_REF...TO_REF` in git.
-    - _new in 2.2.0_: prior to 2.2.0 the arguments were `--source` and
-      `--origin`.
 - `--hook-stage STAGE`: select a [`stage` to run](#confining-hooks-to-run-at-certain-stages).
 - `--show-diff-on-failure`: when hooks fail, run `git diff` directly afterward.
 - `-v`, `--verbose`: produce hook output independent of success.  Include hook

--- a/sections/new-hooks.md
+++ b/sections/new-hooks.md
@@ -37,7 +37,6 @@ file that tells pre-commit:
     =c= [`types_or`](_#hooks-types_or)
     =c= (optional: default `[]`)  list of file types to run on (OR).  See
         [Filtering files with types](#filtering-files-with-types).
-        _new in 2.9.0_.
 =r=
     =c= [`exclude_types`](_#hooks-exclude_types)
     =c= (optional: default `[]`)  the pattern of files to exclude.
@@ -48,7 +47,7 @@ file that tells pre-commit:
 =r=
     =c= [`fail_fast`](_#hooks-fail_fast)
     =c= (optional: default `false`) if `true` pre-commit will stop running
-        hooks if this hook fails.  _new in 2.16.0_.
+        hooks if this hook fails.
 =r=
     =c= [`verbose`](_#hooks-verbose)
     =c= (optional: default `false`) if `true`, forces the output of the hook to be printed even when
@@ -151,7 +150,6 @@ Hello from foo hook!
 - [node](#node)
 - [perl](#perl)
 - [python](#python)
-- [python_venv](#python_venv)
 - [r](#r)
 - [ruby](#ruby)
 - [rust](#rust)
@@ -169,7 +167,7 @@ The `conda` language also supports [`additional_dependencies`](#config-additiona
 and will pass any of the values directly into `conda install`.  This language can therefore be
 used with [local](#repository-local-hooks) hooks.
 
-_new in 2.17.0_: `mamba` or `micromamba` can be used to install instead via the
+`mamba` or `micromamba` can be used to install instead via the
 `PRE_COMMIT_USE_MAMBA=1` or `PRE_COMMIT_USE_MICROMAMBA=1` environment
 variables.
 
@@ -178,8 +176,6 @@ binary (such as [`miniconda`](https://docs.conda.io/en/latest/miniconda.html)).
 It has been tested on linux, macOS, and windows.
 
 ### coursier
-
-_new in 2.8.0_
 
 The hook repository must have a `.pre-commit-channel` folder and that folder
 must contain the coursier
@@ -193,15 +189,13 @@ __Support:__ `coursier` hooks are known to work on any system which has the
 applications you install may depend on various versions of the JVM, consult
 the hooks' documentation for clarification.  It has been tested on linux.
 
-_new in 2.18.0_: pre-commit now supports the `coursier` naming of the package
-manager executable.
+pre-commit also supports the `coursier` naming of the package manager
+executable.
 
 _new in 3.0.0_: `language: coursier` hooks now support `repo: local` and
 `additional_dependencies`.
 
 ### dart
-
-_new in 2.15.0_
 
 The hook repository must have a `pubspec.yaml` -- this must contain an
 `executables` section which will list the binaries that will be available
@@ -274,8 +268,6 @@ For example:
 
 ### dotnet
 
-_new in 2.8.0_
-
 dotnet hooks are installed using the system installation of the dotnet CLI.
 
 Hook repositories must contain a dotnet CLI tool which can be `pack`ed and
@@ -340,8 +332,6 @@ installed.  It has been tested on linux, macOS, and windows.
 
 ### lua
 
-_new in 2.17.0_
-
 Lua hooks are installed with the version of Lua that is used by Luarocks.
 
 __Support:__ Lua hooks are known to work on any system which has Luarocks
@@ -357,8 +347,6 @@ __Support:__ node hooks work without any system-level dependencies.  It has
 been tested on linux, windows, and macOS and _may_ work under cygwin.
 
 ### perl
-
-_new in 2.1.0_
 
 Perl hooks are installed using the system installation of
 [cpan](https://perldoc.perl.org/cpan), the CPAN package installer
@@ -391,23 +379,7 @@ The specified dependencies will be appended to the `pip install` command.
 __Support:__ python hooks work without any system-level dependencies.  It
 has been tested on linux, macOS, windows, and cygwin.
 
-### python_venv
-
-_new in 2.4.0_: The `python_venv` language is now an alias to `python` since
-`virtualenv>=20` creates equivalently structured environments.  Previously,
-this [`language`](#hooks-language) created environments using the [venv] module.
-
-This [`language`](#hooks-language) will be removed eventually so it is suggested to use `python`
-instead.
-
-[venv]: https://docs.python.org/3/library/venv.html
-
-__Support:__ python hooks work without any system-level dependencies.  It
-has been tested on linux, macOS, windows, and cygwin.
-
 ### r
-
-_new in 2.11.0_
 
 This hook repository must have a `renv.lock` file that will be restored with
 [`renv::restore()`](https://rstudio.github.io/renv/reference/restore.html) on
@@ -452,8 +424,8 @@ build _your_ hook repo), or the special syntax
 `cli:{package_name}:{package_version}` for a CLI dependency (built separately,
 with binaries made available for use by hooks).
 
-_new in 2.21.0_: pre-commit will bootstrap `rust` if it is not present.
-`language: rust` also now supports `language_version`
+pre-commit will bootstrap `rust` if it is not present.
+`language: rust` also supports `language_version`
 
 __Support:__ It has been tested on linux, Windows, and macOS.
 
@@ -476,7 +448,7 @@ can apply the `(?i)` flag as the start of your entry, or use `args: [-i]`.
 
 For multiline matches, use `args: [--multiline]`.
 
-_new in 2.8.0_: To require all files to match, use `args: [--negate]`.
+To require all files to match, use `args: [--negate]`.
 
 __Support:__ pygrep hooks are supported on all platforms which pre-commit runs
 on.

--- a/sections/plugins.md
+++ b/sections/plugins.md
@@ -15,8 +15,6 @@ pre-commit config file describes what repositories and hooks are installed.
     =c= (optional: default `[pre-commit]`) a list of `--hook-type`s which will
         be used by default when running
         [`pre-commit install`](#pre-commit-install).
-
-        _new in 2.18.0_
 =r=
     =c= [`default_language_version`](_#top_level-default_language_version)
     =c= (optional: default `{}`) a mapping from language to the default
@@ -129,7 +127,6 @@ repository's configuration.
     =c= [`types_or`](_#config-types_or)
     =c= (optional) override the default file types to run on (OR).  See
         [Filtering files with types](#filtering-files-with-types).
-        _new in 2.9.0_.
 =r=
     =c= [`exclude_types`](_#config-exclude_types)
     =c= (optional) file types to exclude.


### PR DESCRIPTION
- remove `python_venv`
- remove 2.x references