### PR TITLE
Add nbqa to list of hooks

### DIFF
--- a/sections/hooks.md
+++ b/sections/hooks.md
@@ -112,6 +112,7 @@ for other programming languages:
 - [JohnnyMorganz/StyLua]: an opinionated Lua code formatter
 - [Koihik/LuaFormatter]: a formatter for Lua code
 - [mrtazz/checkmake]: linter for Makefile syntax
+- [nbqa-dev/nbqa]: run common linters on Jupyter Notebooks
 
 [realm/SwiftLint]: https://github.com/realm/SwiftLint
 [nicklockwood/SwiftFormat]: https://github.com/nicklockwood/SwiftFormat
@@ -124,6 +125,7 @@ for other programming languages:
 [JohnnyMorganz/StyLua]: https://github.com/JohnnyMorganz/StyLua
 [Koihik/LuaFormatter]: https://github.com/Koihik/LuaFormatter
 [mrtazz/checkmake]: https://github.com/mrtazz/checkmake
+[nbqa-dev/nbqa]: https://github.com/nbQA-dev/nbQA
 
 ## finding hooks
 


### PR DESCRIPTION
I think this fulfills the criteria:

- ✅  the tool must already be fairly popular (>500 stars):
  - it has over 1100 stars, and >300k monthly downloads on PyPI stats
- ✅ the tool must use a managed language (no system / script / docker hooks):
  - yup, it has `types_or: [jupyter, markdown]`
- ✅ the tool must operate on files
  - yup
