### PR TITLE
docs: Update pre-commit-hooks version to v5.0.0

### DIFF
--- a/sections/cli.md
+++ b/sections/cli.md
@@ -29,7 +29,7 @@ Here are some sample invocations using this `.pre-commit-config.yaml`:
 ```yaml
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.1.0
+    rev: v5.0.0
     hooks:
     -   id: trailing-whitespace
 -   repo: https://github.com/asottile/pyupgrade

--- a/sections/install.md
+++ b/sections/install.md
@@ -46,7 +46,7 @@ pre-commit --version
 ```yaml
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v5.0.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer


### PR DESCRIPTION
When using pre-commit-hooks, I copied the version from the website.. But
when I actually use it, it reminds me:

```
[WARNING] repo `https://github.com/pre-commit/pre-commit-hooks` uses deprecated stage names (commit, push) which will be removed in a future version.  Hint: often `pre-commit autoupdate --repo https://github.com/pre-commit/pre-commit-hooks` will fix this.  if it does not -- consider reporting an issue to that repo.
```

So, the `pre-commit-hooks` version should be upgraded to the latest one.
