### PR TITLE
Expand on the phrase `no commits needed` for `try-repo` command

### DIFF
--- a/sections/new-hooks.md
+++ b/sections/new-hooks.md
@@ -107,7 +107,7 @@ _note_: you may need to provide `--commit-msg-filename` when using this
 command with hook types `prepare-commit-msg` and `commit-msg`.
 
 Specifying a commit is not necessary to `try-repo` on a local
-directory, however, the repository must have at least one commit in its history. 
+directory, however, the repository must have at least one commit in its history.
 `pre-commit` will clone any tracked uncommitted changes.
 
 ```pre-commit

--- a/sections/new-hooks.md
+++ b/sections/new-hooks.md
@@ -106,8 +106,9 @@ interactively:
 _note_: you may need to provide `--commit-msg-filename` when using this
 command with hook types `prepare-commit-msg` and `commit-msg`.
 
-a commit is not necessary to `try-repo` on a local
-directory. `pre-commit` will clone any tracked uncommitted changes.
+Specifying a commit is not necessary to `try-repo` on a local
+directory, however, the repository must have at least one commit in its history. 
+`pre-commit` will clone any tracked uncommitted changes.
 
 ```pre-commit
 ~/work/hook-repo $ git checkout origin/main -b feature


### PR DESCRIPTION
I think this language should be improved. 

When I read it, I assumed this meant that you could just `git init` a repo and start developing a plug-in. It seems however, that pre-commit expects there to be a commit on the repo after discussions here:
https://github.com/pre-commit/pre-commit/pull/3441



