### PR TITLE
Update install.md for pipx

### DIFF
--- a/sections/install.md
+++ b/sections/install.md
@@ -7,6 +7,8 @@ Using pip:
 pip install pre-commit
 ```
 
+(In certain OS's such as Ubuntu24 that lock down pip without a custom venv, you may need to use "pipx" instead of "pip")
+
 In a python project, add the following to your requirements.txt (or
 requirements-dev.txt):
 


### PR DESCRIPTION
Save non-python experts a lot of time, by mentioning that pipx exists, and is what ubuntu24 and later need instead of pip.

Otherwise, non-python programmers may spend a lot of time researching how to fix the problem, and worse yet, implement hacks and wrappers that make things ugly.
