### PR TITLE
hooks: add gomarklint to text/docs/prose section

### DIFF
--- a/sections/hooks.md
+++ b/sections/hooks.md
@@ -77,6 +77,7 @@ for text / docs / prose:
 - [amperser/proselint]: A linter for prose.
 - [markdownlint/markdownlint]: a Markdown lint tool in Ruby
 - [DavidAnson/markdownlint-cli2]: a Markdown lint tool in Node
+- [shinagawa-web/gomarklint]: a Markdown lint tool in Go, single binary, no Node.js required
 - [codespell-project/codespell]: check code for common misspellings
 
 [crate-ci/typos]: https://github.com/crate-ci/typos
@@ -84,6 +85,7 @@ for text / docs / prose:
 [amperser/proselint]: https://github.com/amperser/proselint
 [markdownlint/markdownlint]: https://github.com/markdownlint/markdownlint
 [DavidAnson/markdownlint-cli2]: https://github.com/DavidAnson/markdownlint-cli2
+[shinagawa-web/gomarklint]: https://github.com/shinagawa-web/gomarklint
 [codespell-project/codespell]: https://github.com/codespell-project/codespell
 
 for linting commit messages:


### PR DESCRIPTION
## What

Add [shinagawa-web/gomarklint](https://github.com/shinagawa-web/gomarklint) to the **"for text / docs / prose"** section of the featured hooks list.

## Why

gomarklint is a Markdown linter written in Go — a single binary with no Node.js or Ruby runtime required. It fills the gap next to `markdownlint` (Ruby) and `markdownlint-cli2` (Node) by offering a Go-native alternative that is easy to drop into CI pipelines without extra runtime dependencies.

The repo already includes a `.pre-commit-hooks.yaml`:
- hook id: `gomarklint`
- language: `golang`
- types: `[markdown]`

## Links

- Repo: https://github.com/shinagawa-web/gomarklint
- Latest release: v2.8.0
- pre-commit hooks file: https://github.com/shinagawa-web/gomarklint/blob/main/.pre-commit-hooks.yaml