### PR TITLE
Add patchwright/wildlint to supported hooks

### DIFF
--- a/sections/hooks.md
+++ b/sections/hooks.md
@@ -32,6 +32,7 @@ for python projects:
 - [PyCQA/isort]: an import sorter for python
 - [PyCQA/(others)]: a few other python code quality tools
 - [adamchainz/django-upgrade]: automatically upgrade your Django project code
+- [patchwright/wildlint]: a python linter for real-bug classes off-the-shelf linters miss
 
 [asottile/pyupgrade]: https://github.com/asottile/pyupgrade
 [asottile/(others)]: https://sourcegraph.com/search?q=context:global+file:%5E%5C.pre-commit-hooks%5C.yaml%24+repo:%5Egithub.com/asottile/
@@ -43,6 +44,7 @@ for python projects:
 [PyCQA/isort]: https://github.com/PyCQA/isort
 [PyCQA/(others)]: https://sourcegraph.com/search?q=context:global+file:%5E%5C.pre-commit-hooks%5C.yaml%24+repo:%5Egithub.com/PyCQA/
 [adamchainz/django-upgrade]: https://github.com/adamchainz/django-upgrade
+[patchwright/wildlint]: https://github.com/patchwright/wildlint
 
 for shell scripts:
 - [shellcheck-py/shellcheck-py]: runs shellcheck on your scripts


### PR DESCRIPTION
Adds [patchwright/wildlint](https://github.com/patchwright/wildlint) to the Python hooks list.

wildlint is a Python linter ([PyPI](https://pypi.org/project/wildlint/)) for bug classes off-the-shelf linters miss — each rule is distilled from a real upstream fix. Current rules include a dead `argparse` `dest` (flag parses then its value is never read), `str.replace`-as-prefix-strip where `removeprefix`/`removesuffix` was meant, and a few opt-in ones (`str.split(' ')` vs `str.split()`, deep negative indexing, `not A and B or C` precedence).

It ships a `.pre-commit-hooks.yaml` (`id: wildlint`, `language: python`, `types: [python]`), so this config works as-is:

```yaml
repos:
  - repo: https://github.com/patchwright/wildlint
    rev: v0.5.2
    hooks:
      - id: wildlint
```
