### PR TITLE
Fix #1098 - Update the install.md to point to version v6.0.0 of pre-commit-hooks

### DIFF
--- a/sections/install.md
+++ b/sections/install.md
@@ -46,7 +46,7 @@ pre-commit --version
 ```yaml
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v6.0.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer


### PR DESCRIPTION
The example version given in the pre-commit configuration points to version v2.3.0 (2019) of pre-commit-hooks; this commit updates the default version to v6.0.0.